### PR TITLE
add: thirdweb to platform as a service

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@
 - [Infura](https://infura.io)
 - [Moralis](https://moralis.io)
 - [QuickNode](https://www.quicknode.com)
+- [Thirdweb](https://thirdweb.com)
 
 ## Other
 


### PR DESCRIPTION
I add [thirdweb](https://thirdweb.com) to the platform as a service section of the list.

## Checklist

- [x] The URL is not already present in the list (check with CTRL/CMD+F in the raw markdown file).
- [x] Each description starts with an uppercase character and ends with a period.<br>Example: `solc-js - JavaScript bindings for the compiler.`
- [x] Drop all `A` / `An` prefixes at the start of the description.
