### PR TITLE
Changing WalletConnect to RainbowKit

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@
 
 ### Protocol
 
-- [WalletConnect](https://github.com/WalletConnect) - Open protocol connecting wallets to Dapps.
+- [RainbowKit](https://www.rainbowkit.com/) - Open protocol connecting wallets to Dapps.
 - [WalletLink](https://github.com/walletlink/walletlink) - Open protocol that lets users connect their mobile wallets to your DApp.
 - [IPFS](https://ipfs.io) - Distributed system for storing and accessing files, websites, applications, and data.
 


### PR DESCRIPTION
Changed WalletConnect to RainbowKit since WalletConnect is hard to implement and it needs a downgrade from the current version of webpack RainbowKit much more easy to implement to a Dapp. The reason I changed and didn't keep WalletConnect, as I mentioned it is not a finished tool so it may confuse beginners and it is not even an alternative beside RainbowKit.

## Checklist

- [x] The URL is not already present in the list (check with CTRL/CMD+F in the raw markdown file).
- [x] Each description starts with an uppercase character and ends with a period.<br>Example: `solc-js - JavaScript bindings for the compiler.`
- [x] Drop all `A` / `An` prefixes at the start of the description.
