### PR TITLE
Add Robot Framework Solidity Testing Toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@
 
 - [mock-contract](https://github.com/gnosis/mock-contract) - Simple Solidity contract to mock dependent contracts in truffle tests.
 - [openzeppelin-test-helpers](https://github.com/OpenZeppelin/openzeppelin-test-helpers) - Assertion library for Ethereum smart contract testing that you can use with hardhat.
+- [Robot Framework Solidity Testing Toolkit](https://github.com/jg8481/Robot-Framework-Solidity-Testing-Toolkit) - This combines popular smart contract testing and deployment libraries with Robot Framework (a generic RPA ecosystem).
 - [solidity-coverage](https://github.com/sc-forks/solidity-coverage) - Code coverage for Solidity smart-contracts.
 - [Waffle](https://github.com/EthWorks/Waffle) - Library for writing and testing smart contracts.
 


### PR DESCRIPTION
This will add the following Robot Framework toolkit that combines Truffle and Hardhat with [RPA](https://robotframework.org/rpa/).

https://github.com/jg8481/Robot-Framework-Solidity-Testing-Toolkit

## Checklist

- [X] The URL is not already present in the list (check with CTRL/CMD+F in the raw markdown file).
- [X] Each description starts with an uppercase character and ends with a period.<br>Example: `solc-js - JavaScript bindings for the compiler.`
- [X] Drop all `A` / `An` prefixes at the start of the description.
