### PR TITLE
Add Privy to list of JS libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@
 ### JavaScript
 
 - [RainbowKit](https://www.rainbowkit.com/) - React library that makes it easy to add wallet connection to your dapp.
+- [Privy](https://www.privy.io/) - React library to add beautiful authentication flows and powerful connectors to your app.
 - [avalanchejs](https://github.com/ava-labs/avalanchejs) - JavaScript Library for interfacing with the Avalanche Platform.
 - [Avalanche Wallet SDK](https://github.com/ava-labs/avalanche-wallet-sdk) - Typescript library to create and manage wallets on the Avalanche network.
 - [BitcoinJS](https://github.com/bitcoinjs/bitcoinjs-lib) - Bitcoin library for node.js and browsers.


### PR DESCRIPTION
Added Privy to the list of Javascript libraries. Wasn't sure of the alphabetical ordering so added close to Rainbow as a related project.

## Checklist

- [x] The URL is not already present in the list (check with CTRL/CMD+F in the raw markdown file).
- [x] Each description starts with an uppercase character and ends with a period.<br>Example: `solc-js - JavaScript bindings for the compiler.`
- [x] Drop all `A` / `An` prefixes at the start of the description.
