### PR TITLE
Update markdown link checker config

### DIFF
--- a/mlc_config.json
+++ b/mlc_config.json
@@ -1,5 +1,12 @@
 {
   "timeout": "15s",
   "retryOn429": false,
-  "aliveStatusCodes": [200, 206, 429]
+  "aliveStatusCodes": [200, 206, 429],
+  "httpHeaders": [
+    {
+      "headers": {
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
Some sites return HTTP 403 even though they work as expected when an ordinary user agent visits the page.