### PR TITLE
Add libethc to C/C++

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@
 
 ### C/C++
 
+- [libethc](https://github.com/mhw0/libethc) - Open-source Ethereum library in ANSI C.
 - [Trust Wallet Core](https://github.com/trustwallet/wallet-core) - Cross-platform, mobile-focused library implementing low-level cryptographic wallet functionality for a high number of blockchains.
 
 ### Rust


### PR DESCRIPTION
Adds [libethc](https://github.com/mhw0/libethc) into the `C/C++` section.

## Checklist

- [x] The URL is not already present in the list (check with CTRL/CMD+F in the raw markdown file).
- [x] Each description starts with an uppercase character and ends with a period.<br>Example: `solc-js - JavaScript bindings for the compiler.`
- [x] Drop all `A` / `An` prefixes at the start of the description.
