### PR TITLE
Add Solana Playground to Development Environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@
 - [Remix](https://remix.ethereum.org/) - Online IDE for Solidity development.
 - [Foundry](https://book.getfoundry.sh/) - Foundry is blazing fast, portable and modular toolkit for Ethereum application development written in Rust.
 - [Embark](https://github.com/embarklabs/embark) - The all-in-one developer platform for building and deploying decentralized applications.
-- [Solana Playground](https://github.com/solana-playground/solana-playground) - An online IDE to quickly develop and deploy solana programs from the browser.
+- [Solana Playground](https://github.com/solana-playground/solana-playground) - Online IDE to quickly develop and deploy Solana programs that runs on web browser.
 
 ### SDK
 - [Kryptokrona Kotlin SDK](https://github.com/kryptokrona/kryptokrona-kotlin-sdk) - Kryptokrona SDK in Kotlin for building decentralized private communication and payment systems.

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@
 - [Remix](https://remix.ethereum.org/) - Online IDE for Solidity development.
 - [Foundry](https://book.getfoundry.sh/) - Foundry is blazing fast, portable and modular toolkit for Ethereum application development written in Rust.
 - [Embark](https://github.com/embarklabs/embark) - The all-in-one developer platform for building and deploying decentralized applications.
+- [Solana Playground](https://github.com/solana-playground/solana-playground) - An online IDE to quickly develop and deploy solana programs from the browser.
 
 ### SDK
 - [Kryptokrona Kotlin SDK](https://github.com/kryptokrona/kryptokrona-kotlin-sdk) - Kryptokrona SDK in Kotlin for building decentralized private communication and payment systems.


### PR DESCRIPTION
Added Solana Playground which was not present in the list of development environments where other online IDEs were present. 

## Checklist

- [x] The URL is not already present in the list (check with CTRL/CMD+F in the raw markdown file).
- [x] Each description starts with an uppercase character and ends with a period.<br>Example: `solc-js - JavaScript bindings for the compiler.`
- [x] Drop all `A` / `An` prefixes at the start of the description.
