### PR TITLE
Add rivet.cloud to Platform as a Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,7 @@
 - [walletOS](https://www.pinestreetlabs.com/walletos/)
 - [Tenderly](https://tenderly.co)
 - [Apillon](https://apillon.io/)
+- [rivet.cloud](https://rivet.cloud/)
 
 ## Other
 


### PR DESCRIPTION
Add link to rivet.cloud node provider service to the Platform as a Service section