### PR TITLE
Add Ethereum-Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@
 
 - [Chainlist](https://chainlist.org) - List of EVM networks, Chain IDs and Network IDs.
 - [Crypto Payroll](https://www.request.finance/payroll) - Automate and simplify payroll operations in crypto.
+- [Ethereum Ecosystem](https://www.ethereum-ecosystem.com/) - Unofficial Ecosystem page for Ethereum and its Layer 2s featuring 900+ dApps and tools across Optimism, Base, Starknet and more.
 
 ## Contribute
 


### PR DESCRIPTION
Adding [Ethereum-Ecosystem](https://www.ethereum-ecosystem.com/) to the list - an Unofficial Ecosystem page for Ethereum and its Layer 2s featuring 900+ dApps and tools across Optimism, Base, Starknet and more.