### PR TITLE
Add Web3 Antivirus

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@
 - [solc-verify](https://github.com/SRI-CSL/solidity/) - A modular verifier for Solidity smart contracts.
 - [Solidity security blog](https://github.com/sigp/solidity-security-blog) - Comprehensive list of known attack vectors and common anti-patterns.
 - [EVMole](https://github.com/cdump/evmole) - Extracts function selectors from EVM bytecode, even for unverified contracts.
+- [Web3 Antivirus](https://web3antivirus.io) - Browser extension simulating transactions and reporting risks for user-side defense.
 
 ## Open Source Project
 


### PR DESCRIPTION
Adding [Web3 Antivirus](https://web3antivirus.io/) to the Risk Management list

## Checklist

- [x] The URL is not already present in the list (check with CTRL/CMD+F in the raw markdown file).
- [x] Each description starts with an uppercase character and ends with a period.<br>Example: `solc-js - JavaScript bindings for the compiler.`
- [x] Drop all `A` / `An` prefixes at the start of the description.
