### PR TITLE
Add Juno to Platform as a Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@
 - [Apillon](https://apillon.io/)
 - [rivet.cloud](https://rivet.cloud/)
 - [Tatum](https://tatum.io/)
+- [Juno](https://juno.build)
 
 ## Other
 


### PR DESCRIPTION
## Motivation

Hi Ahmet,

I would like to submit the addition of [Juno](https://juno.build/), the project I'm building and hopefully soon a DAO, to the list of Platform-as-a-Service.

Juno is an open-source blockchainless platform for developers to fully own and build apps on Web3, so I thought it fits well in this section.

## Checklist

- [X] The URL is not already present in the list (check with CTRL/CMD+F in the raw markdown file).
- [ ] Each description starts with an uppercase character and ends with a period.<br>Example: `solc-js - JavaScript bindings for the compiler.`
- [ ] Drop all `A` / `An` prefixes at the start of the description.

## Notes

I did not provide a description as mentioned in the checklist for consistency, since no other platforms in this chapter include one. However, I'm happy to provide a description if you'd prefer.
