### PR TITLE
Typo fix in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@
 - [Blockchain Scalability](https://github.com/lucadonnoh/awesome-blockchain-scalability) - Curated list of awesome resources about blockchain scalability.
 - [MakerDAO](https://github.com/makerdao/awesome-makerdao) - Collection of tools, documents, articles, blog posts, interviews, and videos related to MakerDAO and the Dai stablecoin.
 - [Kiwi](https://github.com/attestate/awesome-kiwinews) - Collection of documents, clients, apps, APIs, and other resources related to Kiwi protocol.
-- [Accout Abstraction](https://github.com/4337Mafia/awesome-account-abstraction) - Collection of account abstraction resources.
+- [Account Abstraction](https://github.com/4337Mafia/awesome-account-abstraction) - Collection of account abstraction resources.
 - [ETH Gas Tracker](https://www.ethgastracker.com/) - Monitor and track Ethereum and L2 gas prices to reduce transaction fees, save money and take control of your blockchain experience
 
 ## Reference


### PR DESCRIPTION
Corrected a typographical error in the README.md file:  
- Fixed "Accout Abstraction" to "Account Abstraction" under the "Awesome List" section.  

### Checklist  
- [x] The URL is not already present in the list (checked with CTRL/CMD+F in the raw markdown file).  
- [x] Each description starts with an uppercase character and ends with a period.  
- [x] Dropped all `A` / `An` prefixes at the start of the description.  