### PR TITLE
docs: Fix Typo in "Polybase" Database Section Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@
 - [OrbitDB](https://github.com/orbitdb/orbit-db) - Serverless, distributed, peer-to-peer database.
 - [DB3](https://github.com/dbpunk-labs/db3) - DB3 is a community-driven layer2 decentralized database network, a firebase firestore alternative.
 - [WeaveDB](https://github.com/weavedb/weavedb) - WeaveDB is NoSQL Database as Smart Contract Bringing web2-like smooth UX, complexity, and scalability to web3 dApps.
-- [Polybase](https://github.com/polybase/) - Polybase is a drop-in replacement for Firebase, Firstore alongside 10x better db permissions with ZK + Wallet Auth.
+- [Polybase](https://github.com/polybase/) - Polybase is a drop-in replacement for Firebase, Firestore alongside 10x better db permissions with ZK + Wallet Auth.
 
 ### Datasets
 


### PR DESCRIPTION
## Description
I noticed a typo in the "Polybase" section under the "Database" category. The word "Firstore" was incorrectly used, and it should be "**Firestore**." This correction ensures that the description accurately refers to the Firebase Firestore database.

Here’s the updated sentence:
> "Polybase is a drop-in replacement for Firebase, Firestore alongside 10x better db permissions with ZK + Wallet Auth."

## Checklist

- [ ] The URL is not already present in the list (check with CTRL/CMD+F in the raw markdown file).
- [ ] Each description starts with an uppercase character and ends with a period.<br>Example: `solc-js - JavaScript bindings for the compiler.`
- [ ] Drop all `A` / `An` prefixes at the start of the description.
