### PR TITLE
fix: missing `join` import in `getStaticProps`

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -1,5 +1,6 @@
 import { readFileSync } from 'fs'
 import { unified } from 'unified'
+import { join } from 'path';
 import remarkParse from 'remark-parse'
 import remarkRehype from 'remark-rehype'
 import rehypeRaw from 'rehype-raw'


### PR DESCRIPTION
Hey! I noticed that `join` was used in `getStaticProps`, but it wasn’t imported, which would throw a `ReferenceError`.
Just added `import { join } from 'path'`, and everything should work smoothly now.

## Checklist

- [ ] The URL is not already present in the list (check with CTRL/CMD+F in the raw markdown file).
- [ ] Each description starts with an uppercase character and ends with a period.<br>Example: `solc-js - JavaScript bindings for the compiler.`
- [ ] Drop all `A` / `An` prefixes at the start of the description.
