### PR TITLE
chore: fix Tailwind CSS import to use global styles

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,4 +1,4 @@
-import 'tailwindcss/tailwind.css'
+import '@/styles/globals.css'
 import { Analytics } from '@vercel/analytics/react'
 import { SpeedInsights } from '@vercel/speed-insights/next'
 


### PR DESCRIPTION
Replaced `import 'tailwindcss/tailwind.css'` with `import '@/styles/globals.css'`.
Tailwind CSS doesn’t provide `tailwind.css` as a standalone file in `node_modules`, and styles should be included via a global CSS file instead.