### PR TITLE
Remove defunct basement.dev link

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,7 +427,6 @@
 - [GetBlock](https://getblock.io/)
 - [Ankr](https://www.ankr.com/)
 - [SimpleHash](https://simplehash.com)
-- [Basement](https://basement.dev/)
 - [walletOS](https://www.pinestreetlabs.com/walletos/)
 - [Tenderly](https://tenderly.co)
 - [Apillon](https://apillon.io/)


### PR DESCRIPTION

The link to `https://basement.dev/` has been removed since the site no longer exists.

## Checklist

- [ ] The URL is not already present in the list (check with CTRL/CMD+F in the raw markdown file).
- [ ] Each description starts with an uppercase character and ends with a period.<br>Example: `solc-js - JavaScript bindings for the compiler.`
- [ ] Drop all `A` / `An` prefixes at the start of the description.
