### PR TITLE
Remove dead link to Meson Network

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,7 +426,6 @@
 - [QuickNode](https://www.quicknode.com)
 - [Thirdweb](https://thirdweb.com)
 - [Kriptonio](https://kriptonio.com)
-- [Meson Network](https://meson.network)
 - [Chainstack](https://chainstack.com/)
 - [GetBlock](https://getblock.io/)
 - [Ankr](https://www.ankr.com/)


### PR DESCRIPTION
I removed the link to [https://meson.network/](https://meson.network/) since the project is no longer active and the site is down.

## Checklist

- [ ] The URL is not already present in the list (check with CTRL/CMD+F in the raw markdown file).
- [ ] Each description starts with an uppercase character and ends with a period.<br>Example: `solc-js - JavaScript bindings for the compiler.`
- [ ] Drop all `A` / `An` prefixes at the start of the description.
