### PR TITLE
docs: remove broken link to minting.tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,6 @@
 - [ChainJet](https://chainjet.io) - No-code platform for building on-chain or off-chain task automations. Use ChainJet to integrate multiple web3 services to automate all kinds of tasks.
 - [Layer4](https://www.layer4.app) - No-code and low-code blockchain integration platform. Deploy standard token contracts or persist data on-chain with a few clicks.
 - [WalletConnect](https://novabloq.com/plugin/walletconnect-official-1671213284712x803510314952042000) - Web3Modal v2 SDK with updated UI integrated into a plugin for bubble.io - Connect a wallet, sign a message, detect chain or account changed.
-- [Minting.tools](https://minting.tools) - No-code ERC20 token generator. Free to use, shares flattened contract code for verification after deployment. Works with any EVM blockchain. Only requirement is a Web3 wallet, and gas on the chain you'd like to use.
 
 ### Boilerplate
 


### PR DESCRIPTION
Noticed that the link to `https://minting.tools` no longer works — the domain seems to be down or gone entirely.
I’ve removed the reference to avoid confusion or dead-end navigation. 

## Checklist

- [ ] The URL is not already present in the list (check with CTRL/CMD+F in the raw markdown file).
- [ ] Each description starts with an uppercase character and ends with a period.<br>Example: `solc-js - JavaScript bindings for the compiler.`
- [ ] Drop all `A` / `An` prefixes at the start of the description.
