### PR TITLE
docs: Fixed incorrect IPFS link

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@
 
 - [WalletConnect](https://github.com/WalletConnect) - Open protocol connecting wallets to Dapps.
 - [WalletLink](https://github.com/walletlink/walletlink) - Open protocol that lets users connect their mobile wallets to your DApp.
-- [IPFS](https://ipfs.io) - Distributed system for storing and accessing files, websites, applications, and data.
+- [IPFS](https://ipfs.tech/) - Distributed system for storing and accessing files, websites, applications, and data.
 - [Lens Protocol](https://www.lens.xyz/) - Lens Protocol is composable and decentralized social graph, ready for you to build on so you can focus on creating a great experience, not scaling your users.
 - [Aave Protocol](https://aave.com/) - Aave is decentralized non-custodial liquidity protocol where users can participate as depositors or borrowers.
 - [SmartWeave](https://github.com/ArweaveTeam/SmartWeave) - SmartWeave is smart contract protocol that allows developers to build permanent applications on top of Arweave.


### PR DESCRIPTION
Saw the IPFS link was outdated - updated it to the correct one: https://ipfs.tech/

## Checklist

- [ ] The URL is not already present in the list (check with CTRL/CMD+F in the raw markdown file).
- [ ] Each description starts with an uppercase character and ends with a period.<br>Example: `solc-js - JavaScript bindings for the compiler.`
- [ ] Drop all `A` / `An` prefixes at the start of the description.
