### PR TITLE
docs: fix typo and improve Uniswap protocol description

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@
 - [Ceramic Network](https://github.com/ceramicnetwork) - Ceramic is decentralized data network that brings unlimited data composability to Web3 applications.
 - [Polkadot](https://polkadot.network/) - Polkadot is scalable, interoperable & secure network protocol for the next web.
 - [zkSync](https://zksync.io/) - Protocol zkSync is trustless protocol that uses cryptographic validity proofs to provide scalable and low-cost transactions on Ethereum.
-- [Uniswap](https://uniswap.org/) - Uniswap is protocol for trading and automated liquidity provision on Ethereum.
+- [Uniswap](https://uniswap.org/) - Uniswap is a protocol for trading and automated liquidity provision on Ethereum.
 - [NEAR](https://near.org/) - NEAR is smart-contract compatible blockchain, designed and built to support the development of highly secure and scalable dApps.
 - [Arweave](https://www.arweave.org/) - Arweave is protocol that allows you to permanently and sustainably store data for a single upfront fee.
 - [Livepeer](https://livepeer.org/) - Livepeer is Ethereum-based protocol that distributes video transcoding work throughout its decentralized network.


### PR DESCRIPTION
**Description:**  
Noticed a small typo in the Uniswap section—missing article “a” in the description. 
## Checklist

- [ ] The URL is not already present in the list (check with CTRL/CMD+F in the raw markdown file).
- [ ] Each description starts with an uppercase character and ends with a period.<br>Example: `solc-js - JavaScript bindings for the compiler.`
- [ ] Drop all `A` / `An` prefixes at the start of the description.
