### PR TITLE
docs: Fix minor grammar mistake in Livepeer description

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@
 - [Uniswap](https://uniswap.org/) - Uniswap is a protocol for trading and automated liquidity provision on Ethereum.
 - [NEAR](https://near.org/) - NEAR is smart-contract compatible blockchain, designed and built to support the development of highly secure and scalable dApps.
 - [Arweave](https://www.arweave.org/) - Arweave is protocol that allows you to permanently and sustainably store data for a single upfront fee.
-- [Livepeer](https://livepeer.org/) - Livepeer is Ethereum-based protocol that distributes video transcoding work throughout its decentralized network.
+- [Livepeer](https://livepeer.org/) - Livepeer is an Ethereum-based protocol that distributes video transcoding work throughout its decentralized network.
 - [Compound](https://compound.finance/) - Compound is algorithmic, autonomous interest rate protocol built for developers, to unlock universe of open financial applications.
 - [Euler](https://www.euler.finance/) - Euler is non-custodial protocol on Ethereum that allows users to lend and borrow almost any crypto asset.
 - [Unitas](https://unitas.foundation/) - Unitas Protocol enables financial sovereignty by granting people the right to choose their units of account while transacting with each other.


### PR DESCRIPTION
Noticed a small grammatical error in the Livepeer description—missing article before "Ethereum-based protocol."
Updated it to say "**an Ethereum-based protocol**" for clarity and correctness.

## Checklist

- [ ] The URL is not already present in the list (check with CTRL/CMD+F in the raw markdown file).
- [ ] Each description starts with an uppercase character and ends with a period.<br>Example: `solc-js - JavaScript bindings for the compiler.`
- [ ] Drop all `A` / `An` prefixes at the start of the description.
