### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -2,6 +2,9 @@ name: Markdown Links Check
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   markdown-link-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ahmet/awesome-web3/security/code-scanning/2](https://github.com/ahmet/awesome-web3/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the workflow level (root) to restrict the permissions of the `GITHUB_TOKEN`. Since the workflow only checks markdown links, it only requires read access to the repository contents. We will set `contents: read` as the minimal required permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
