### PR TITLE
Add Slippy to Code Quality section

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@
 
 ### Code Quality
 
+- [Slippy](https://github.com/slippy-lint/slippy) - Simple and powerful linter for Solidity.
 - [Slither](https://github.com/crytic/slither) - Solidity static analysis framework, a suite of vulnerability detectors, prints visual information about contract details etc.
 - [solhint](https://github.com/protofire/solhint) - Solidity linter providing Security and Style Guide validations.
 


### PR DESCRIPTION
Hi, I'm adding a project of mine, [Slippy](https://github.com/slippy-lint/slippy), to the "Code quality" section. Slippy is a new linter for solidity I've been working on for the last couple of months. It has already been adopted [by some serious projects](https://github.com/search?q=path%3A**%2Fslippy.config.js&type=code&ref=advsearch) and a couple of popular templates.

## Checklist

- [x] The URL is not already present in the list (check with CTRL/CMD+F in the raw markdown file).
- [x] Each description starts with an uppercase character and ends with a period.<br>Example: `solc-js - JavaScript bindings for the compiler.`
- [x] Drop all `A` / `An` prefixes at the start of the description.