### PR TITLE
CI: migrate workflows to checkout v6

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -9,7 +9,7 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
         file-path: './README.md'


### PR DESCRIPTION
Update checkout action to v6. Better credential handling in containers.

https://github.com/actions/checkout/releases/tag/v6.0.0