### PR TITLE
Add Filebase to hosting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@
 ### Hosting
 
 - [dAppling Network](https://www.dappling.network/) - Decentralized web hosting platform for Web3 frontends focusing on increasing uptime, security, and providing an additional access point for users.
+- [Filebase](https://filebase.com/) - Filebase is an InterPlanetary development platform, providing users with quick access to IPFS storage, dedicated IPFS gateways, and IPNS names.
 
 ### SDK
 


### PR DESCRIPTION
Filebase is the leading InterPlanetary development platform, providing users with quick access to IPFS storage, dedicated IPFS gateways, and IPNS names.  

Filebase also has an S3-compatible API that plugs directly into IPFS — no blockchain knowledge required.

Basically It is a web3 version of AWS S3. 

## Checklist

- [x] The URL is not already present in the list (check with CTRL/CMD+F in the raw markdown file).
- [x] Each description starts with an uppercase character and ends with a period.<br>Example: `solc-js - JavaScript bindings for the compiler.`
- [x] Drop all `A` / `An` prefixes at the start of the description.
