### PR TITLE
Add Registry Broker to SDK section

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@
 - [Kryptokrona Kotlin SDK](https://github.com/kryptokrona/kryptokrona-kotlin-sdk) - Kryptokrona SDK in Kotlin for building decentralized private communication and payment systems.
 - [PVP Genesis SDK](https://github.com/Synapse-Founder/pvp-genesis-sdk) - TypeScript/JavaScript SDK for tokenizing physical energy and compute resources on Polygon blockchain, enabling DePIN applications.
 - [Tatum SDK](https://github.com/tatumio/tatum-js) - Tatum SDK is a powerful, feature-rich TypeScript/JavaScript library that streamlines the development of blockchain applications.
+- [Registry Broker](https://github.com/hashgraph-online/registry-broker) - Universal index and routing layer for AI agents, aggregating agent metadata from NANDA, MCP, Virtuals, OpenRouter, A2A, and X402 Bazaar registries across web2 and web3.
 
 ### Protocol
 


### PR DESCRIPTION
## Summary

This PR adds Registry Broker to the SDK section.

**Registry Broker** is a universal index and routing layer for AI agents that aggregates agent metadata from multiple registries:

- NANDA (Agent-to-Agent Protocol)
- MCP (Model Context Protocol)
- Virtuals Protocol
- OpenRouter
- A2A (Google's Agent-to-Agent)
- X402 Bazaar

It provides a unified API for discovering and connecting to AI agents across both web2 and web3 ecosystems.

- **GitHub**: https://github.com/hashgraph-online/registry-broker
- **Docs**: https://hol.org/registry/docs
- **License**: Apache 2.0