### PR TITLE
Add Hashgraph Online Standards SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@
 
 ### SDK
 
+- [Hashgraph Online Standards SDK](https://github.com/hashgraph-online/standards-sdk) - TypeScript SDK for Hedera Consensus Service standards (HCS-1 through HCS-11), enabling decentralized file storage, NFT metadata, and recursive content on Hedera.
 - [Kryptokrona Kotlin SDK](https://github.com/kryptokrona/kryptokrona-kotlin-sdk) - Kryptokrona SDK in Kotlin for building decentralized private communication and payment systems.
 - [PVP Genesis SDK](https://github.com/Synapse-Founder/pvp-genesis-sdk) - TypeScript/JavaScript SDK for tokenizing physical energy and compute resources on Polygon blockchain, enabling DePIN applications.
 - [Tatum SDK](https://github.com/tatumio/tatum-js) - Tatum SDK is a powerful, feature-rich TypeScript/JavaScript library that streamlines the development of blockchain applications.


### PR DESCRIPTION
Adds the Hashgraph Online Standards SDK to the SDK section.

TypeScript SDK for Hedera Consensus Service standards (HCS-1 through HCS-11), enabling decentralized file storage, NFT metadata, and recursive content on Hedera.

- GitHub: https://github.com/hashgraph-online/standards-sdk
- NPM: https://www.npmjs.com/package/@hashgraphonline/standards-sdk
- License: Apache 2.0