### PR TITLE
Add dexscraper to Python resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@
 - [py-evm](https://github.com/ethereum/py-evm) - Ethereum protocol implementation in Python.
 - [Vyper](https://github.com/vyperlang/vyper) - Contract-oriented, pythonic programming language that targets EVM.
 - [web3.py](https://github.com/ethereum/web3.py) - Python interface for interacting with the Ethereum blockchain and ecosystem.
+- [dexscraper](https://github.com/vincentkoc/dexscraper) - Python SDK and CLI for extracting real-time DexScreener market data over WebSocket and API.
 
 ### Dart
 


### PR DESCRIPTION
Adds [dexscraper](https://github.com/vincentkoc/dexscraper) under Python resources as a market-data SDK/CLI for DexScreener APIs and WebSocket streams.