### PR TITLE
Add Chitin: On-chain soul identity and DID for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@
 - [Synapse](https://synapseprotocol.com/) - Synapse Protocol enables cross-chain communication for facilitating transactions across blockchains.
 - [Router Protocol](https://github.com/router-resources/RouterProtocol) - Router Protocol bridges different layer 1 and layer 2 blockchains, enabling seamless cross-chain liquidity migration in DeFi. It facilitates token transfers between chains and cross-chain execution of operations.
 - [x402](https://github.com/xpaysh/awesome-x402) - Internet-native payment protocol using HTTP 402 status code for blockchain payments.
+- [Chitin](https://chitin.id) - On-chain soul identity for AI agents on Base L2. W3C DID resolution (did:chitin), Soulbound Tokens (EIP-5192), ERC-8004 agent passports, verifiable certificates, and governance voting. ([GitHub](https://github.com/Tiida-Tech/chitin-contracts))
 
 ### JavaScript
 


### PR DESCRIPTION
Adds [Chitin](https://chitin.id) to the Identity/DID section.

Chitin provides on-chain soul identity for AI agents on Base L2:
- W3C DID resolution (did:chitin:8453:{name})
- Soulbound Tokens (EIP-5192) as permanent birth certificates
- ERC-8004 agent passports for cross-chain identity
- Verifiable on-chain certificates and governance voting
- Open source smart contracts (MIT): https://github.com/Tiida-Tech/chitin-contracts
- MCP server: https://www.npmjs.com/package/chitin-mcp-server

Live on Base Mainnet.