### PR TITLE
Add MolTrust — Trust Infrastructure for AI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@
 - [Router Protocol](https://github.com/router-resources/RouterProtocol) - Router Protocol bridges different layer 1 and layer 2 blockchains, enabling seamless cross-chain liquidity migration in DeFi. It facilitates token transfers between chains and cross-chain execution of operations.
 - [x402](https://github.com/xpaysh/awesome-x402) - Internet-native payment protocol using HTTP 402 status code for blockchain payments.
 - [Chitin](https://chitin.id) - On-chain soul identity for AI agents on Base L2. W3C DID resolution (did:chitin), Soulbound Tokens (EIP-5192), ERC-8004 agent passports, verifiable certificates, and governance voting. ([GitHub](https://github.com/Tiida-Tech/chitin-contracts))
+- [MolTrust](https://moltrust.ch) - Trust infrastructure for AI agents. W3C DID identity verification, reputation scoring, Ed25519-signed Verifiable Credentials, and Base blockchain anchoring. ([SDK](https://github.com/MoltyCel/moltrust-sdk) · [PyPI](https://pypi.org/project/moltrust/) · [API Docs](https://api.moltrust.ch/docs))
 
 ### JavaScript
 


### PR DESCRIPTION
## Summary

Adds [MolTrust](https://moltrust.ch) to the **Protocol** section.

MolTrust provides trust infrastructure for AI agents:
- W3C DID identity verification (`did:web`)
- Reputation scoring (1-5 star peer ratings)
- Ed25519-signed Verifiable Credentials
- Base blockchain anchoring for on-chain proof

Similar to Chitin (already listed), but focused on agent-to-agent trust verification before transactions.

- Website: https://moltrust.ch
- SDK: `pip install moltrust` · [GitHub](https://github.com/MoltyCel/moltrust-sdk)
- API Docs: https://api.moltrust.ch/docs