### PR TITLE
Add py-ethclient to Python section

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@
 - [Vyper](https://github.com/vyperlang/vyper) - Contract-oriented, pythonic programming language that targets EVM.
 - [web3.py](https://github.com/ethereum/web3.py) - Python interface for interacting with the Ethereum blockchain and ecosystem.
 - [dexscraper](https://github.com/vincentkoc/dexscraper) - Python SDK and CLI for extracting real-time DexScreener market data over WebSocket and API.
+- [py-ethclient](https://github.com/tokamak-network/py-ethclient) - Python Ethereum L1 execution client built from scratch — EVM, RLPx, eth/68, snap/1, full & snap sync, Engine API, and JSON-RPC.
 
 ### Dart
 


### PR DESCRIPTION
## Summary

Add [py-ethclient](https://github.com/tokamak-network/py-ethclient) to the **Python** section under Software Development.

py-ethclient is a fully independent Python Ethereum L1 execution client built from scratch:

- **EVM** with 140+ opcodes and precompiles (ecrecover, BN128, BLAKE2f, KZG)
- **P2P networking** via RLPx with eth/68 and snap/1 wire protocols
- **Sync**: full sync and snap sync (tested on Mainnet and Sepolia)
- **Engine API** V1/V2/V3 with JWT authentication
- **JSON-RPC 2.0** with 20+ methods
- **15,271 LOC**, 593 passing tests

It complements the existing `py-evm` entry as a complete execution client implementation.

https://github.com/tokamak-network/py-ethclient