### PR TITLE
Add NanoStack to Rust section

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,8 +228,9 @@
 
 ### Rust
 
-- [Reth](https://github.com/paradigmxyz/reth) - Modular, contributor-friendly and blazing-fast implementation of the Ethereum protocol, in Rust.
+- [NanoStack](https://github.com/nano-labs-io/nanostack-api) - Permissionless cross-chain execution API — 59 chains, 8-15 bps fees, real-time signal data with BLAKE3 proofs.
 - [OpenEthereum](https://github.com/openethereum/openethereum) - The fast, light, and robust client for the Ethereum mainnet.
+- [Reth](https://github.com/paradigmxyz/reth) - Modular, contributor-friendly and blazing-fast implementation of the Ethereum protocol, in Rust.
 
 ### Shell
 


### PR DESCRIPTION
## What

Adds [NanoStack](https://github.com/nano-labs-io/nanostack-api) to the Rust section under Software Development.

## Entry

```
- [NanoStack](https://github.com/nano-labs-io/nanostack-api) - Permissionless cross-chain execution API — 59 chains, 8-15 bps fees, real-time signal data with BLAKE3 proofs.
```

## Why it fits

- Rust implementation, std-only core with no third-party dependencies on the hot path
- Covers 59 chains: BTC, EVM (ETH/Base/ARB/OP), Solana, Cosmos, Polkadot, XRP, Cardano, and more
- Permissionless execution — no API key required
- BLAKE3-proofed receipts for cryptographic verification
- Relevant to Web3 developers building cross-chain tooling in Rust