### PR TITLE
Add Human Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,7 @@
 - [Kriptonio](https://kriptonio.com)
 - [Chainstack](https://chainstack.com/)
 - [GetBlock](https://getblock.io/)
+- [Human Pages](https://humanpages.ai) - The open directory AI agents use to hire humans for real-world tasks. USDC payments on Base, x402 pay-per-use protocol. Zero platform fees.
 - [Ankr](https://www.ankr.com/)
 - [SimpleHash](https://simplehash.com)
 - [walletOS](https://www.pinestreetlabs.com/walletos/)


### PR DESCRIPTION
Adds [Human Pages](https://humanpages.ai) — the open directory AI agents use to hire humans for real-world tasks. USDC payments on Base, x402 pay-per-use protocol. Zero platform fees.

- Website: https://humanpages.ai
- GitHub: https://github.com/human-pages-ai/humanpages