### PR TITLE
Add Web3 Trackers to Other section

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,7 @@
 - [Ethereum Ecosystem](https://www.ethereum-ecosystem.com/) - Unofficial Ecosystem page for Ethereum and its Layer 2s featuring 900+ dApps and tools across Optimism, Base, Starknet and more.
 - [Formo](https://formo.so) - Web3 forms and product analytics for web3 teams.
 - [SailOnChain](https://sailonchain.com) - Crypto & Web3 job board with 1,400+ positions, salary intelligence, and global remote roles from ~2,000 blockchain companies.
+- [Web3 Trackers](https://www.web3trackers.com) - Marketing attribution for crypto: track which campaigns drive wallet connects and on-chain conversions across Ethereum, Base, Solana, and TON.
 
 ## Contribute
 


### PR DESCRIPTION
Adds [Web3 Trackers](https://www.web3trackers.com) to the **Other** section.

Web3 Trackers is a marketing attribution platform for crypto teams. It tracks which campaigns (UTM links, KOL posts, Discord invites) drive wallet connects and on-chain conversions across Ethereum, Base, Solana, and TON. Free tier available.