### PR TITLE
Add cipher-starter (solo Solana signal engine playbook) to Open Source Project

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,7 @@
 - [Pulse](https://github.com/manja316/pulse-payments) - Instant payment links on Base. Create shareable payment requests settled onchain with 0.5% fee.
 - [Pact](https://github.com/manja316/pact-escrow) - Trustless freelance escrow on Base. Lock funds in a smart contract, release on milestone completion.
 - [Drift](https://github.com/manja316/drift-subscriptions) - Onchain subscription payments on Base. Recurring crypto payments with auto-debit smart contracts.
+- [cipher-starter](https://github.com/cryptomotifs/cipher-starter) - Solo Solana signal engine + autonomous trading bot playbook: 150-page bundle (MIT) covering universe selection, MEV sandwich defenses, three-tier wallet architecture, risk circuit breakers, Canadian compliance memo, and Oracle Cloud Always Free deploy blueprint.
 
 ## Tutorial
 


### PR DESCRIPTION
Adding **cipher-starter** to **Open Source Project**.

A 150-page MIT-licensed playbook for solo devs building a Solana-native signal engine + autonomous trading bot on $0/mo infrastructure. 12 playbooks covering: trading universe + top-K signal filtering, eighth-Kelly sizing, 5-breaker risk rails, three-tier wallet architecture ($100 hot / $300 warm / $600 cold) with KMS envelope + isolated signer subprocess, MEV sandwich defenses via Jito bundles + oracle gates, Canadian NI 31-103 compliance memo, Oracle Cloud Always Free deploy blueprint, and a ~1000-tool audit with 30 P0 picks.

- Repo: https://github.com/cryptomotifs/cipher-starter
- Landing: https://cryptomotifs.github.io/cipher-starter/

Happy to move to a different section if this isn't the best fit.
