### PR TITLE
Add awesome-web3-jobs to Awesome List

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@
 - [Kiwi](https://github.com/attestate/awesome-kiwinews) - Collection of documents, clients, apps, APIs, and other resources related to Kiwi protocol.
 - [Account Abstraction](https://github.com/4337Mafia/awesome-account-abstraction) - Collection of account abstraction resources.
 - [x402](https://github.com/xpaysh/awesome-x402) - Internet-native payment protocol using HTTP 402 status code for blockchain payments.
+- [Web3 Jobs](https://github.com/ceosvex/awesome-web3-jobs) - Curated list of job boards, companies, salary data, and career resources for finding web3 and crypto jobs.
 
 ## Reference
 


### PR DESCRIPTION
Adds [awesome-web3-jobs](https://github.com/ceosvex/awesome-web3-jobs) — a curated list of job boards, direct company career pages, newsletters, salary data, guides, and interview-prep resources for web3 and crypto hiring. Fits the 'Awesome List' section alongside peers like awesome-solidity, awesome-ethereum, awesome-web3-security.