### PR TITLE
Update Hive Intelligence description to current positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@
 ## AI & LLM & MCP
 
 - [dRPC Agent Skills](https://github.com/drpcorg/drpc-agent-skills) - Read-only on-chain data for AI agents via DRPC's node network. Covers all major EVM networks and Solana. Free API key at drpc.org.
-- [Hive Intelligence](https://github.com/hive-intel/hive-crypto-mcp) 📇 ☁️ 🏠 - Hive Intelligence: Ultimate cryptocurrency MCP for AI assistants with unified access to crypto, DeFi, and Web3 analytics.
+- [Hive Intelligence](https://github.com/hive-intel/hive-crypto-mcp) 🎖️ 📇 ☁️ 🏠 - Institutional-grade crypto market infrastructure for AI — live prices, DeFi, wallets, and token risk through a managed MCP, REST API, or CLI.
 - [Hashgraph Online (HOL)](https://github.com/hashgraph-online) - Universal agentic registry on Hedera providing blockchain-based identity for AI agents via HCS-14 Universal Agent IDs (UAIDs). Bridges A2A, ERC-8004, x402, and MCP protocols. 187K+ verified agents, 33M+ daily operations. Open-source SDKs: TypeScript, Go, Python.
 - [Pythia Oracle MCP](https://github.com/pythia-the-oracle/pythia-oracle-mcp) - On-chain calculated indicators (EMA, RSI, Bollinger, Volatility) for 22 tokens via Chainlink. MCP server + LangChain integration for AI agents to access DeFi data.
 - [Hedera Agent Kit](https://docs.hedera.com/hedera/open-source-solutions/ai-studio-on-hedera/hedera-ai-agent-kit) - Open-source framework for building AI-powered applications that interact with the Hedera Network. Create conversational agents that understand natural language and execute Hedera transactions, or build backend systems that leverage AI for on-chain operations.


### PR DESCRIPTION
Refreshes Hive Intelligence's description to match the current canonical product positioning on [hiveintelligence.xyz](https://hiveintelligence.xyz) and the `hive-intel/hive-crypto-mcp` repo's updated GitHub description.

**What Hive is** (unchanged): managed crypto-market infrastructure that gives AI agents one endpoint for live crypto prices, DeFi activity, wallet positions, and token risk across every major chain. Works with Claude Desktop, Claude Code, Cursor, ChatGPT Desktop, Windsurf, VS Code (GitHub Copilot Chat), Gemini CLI, and any MCP-compatible client.

**Changes in this PR**:
- Description rewritten to reflect current positioning.
- Added the 🎖️ "official implementation" flag — Hive operates this MCP server directly.
- Calls out REST API and CLI alongside MCP, since Hive exposes three surfaces on the same endpoint.

No structural changes: same link, same flags, same position in the Datasets section.