### PR TITLE
Add Sharpe Rug Check to Risk Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@
 - [EVMole](https://github.com/cdump/evmole) - Extracts function selectors from EVM bytecode, even for unverified contracts.
 - [Web3 Antivirus](https://web3antivirus.io) - Browser extension simulating transactions and reporting risks for user-side defense.
 - [PolicyLayer](https://policylayer.com) - Non-custodial spending controls for AI agents with crypto wallets. Enforce daily limits, per-transaction caps, and recipient whitelists without holding private keys.
+- [Sharpe Rug Check](https://www.sharpe.ai/rug-check) - Free token safety scanner and rug pull checker with a 0-100 risk score across Solana, Ethereum, Base, BSC, Arbitrum, and Polygon. Honeypot simulation, mint-authority detection, liquidity-lock verification, and holder-concentration analysis. No signup, public REST API.
 
 ### x402 Payments Protocol
 


### PR DESCRIPTION
Adding [Sharpe Rug Check](https://www.sharpe.ai/rug-check) to the Risk Management section, alongside the existing user-side defense tools (Web3 Antivirus, PolicyLayer).

**What it is:** A free token safety scanner and rug pull checker. Paste any token contract address to get a 0-100 risk score before trading.

**Coverage:**
- 6 chains: Solana (SPL + Token-2022 transfer-hook honeypots), Ethereum, Base, BSC, Arbitrum, Polygon
- 30+ risk patterns: honeypot simulation, mint/freeze/update authority, EIP-1967 proxy upgrade detection, blacklist/pause functions, hidden sell tax, liquidity lock and duration, top-10 holder concentration, insider-cluster detection
- Free, no signup
- Public REST API for bot/agent integration

**URL:** https://www.sharpe.ai/rug-check

Formatting matches the existing Risk Management entries.