### PR TITLE
Add RustChain to Rust section

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,6 @@
 - [Router Protocol](https://github.com/router-resources/RouterProtocol) - Router Protocol bridges different layer 1 and layer 2 blockchains, enabling seamless cross-chain liquidity migration in DeFi. It facilitates token transfers between chains and cross-chain execution of operations.
 - [Chitin](https://chitin.id) - On-chain soul identity for AI agents on Base L2. W3C DID resolution (did:chitin), Soulbound Tokens (EIP-5192), ERC-8004 agent passports, verifiable certificates, and governance voting. ([GitHub](https://github.com/Tiida-Tech/chitin-contracts))
 - [MolTrust](https://moltrust.ch) - Trust infrastructure for AI agents. W3C DID identity verification, reputation scoring, Ed25519-signed Verifiable Credentials, and Base blockchain anchoring. ([SDK](https://github.com/MoltyCel/moltrust-sdk) · [PyPI](https://pypi.org/project/moltrust/) · [API Docs](https://api.moltrust.ch/docs))
-- [RustChain](https://rustchain.org) - Proof-of-Antiquity blockchain that rewards mining on vintage hardware (PowerPC G4, Pentium 4) with RTC tokens. Features 6-point hardware fingerprinting, Ergo chain anchoring, and an on-chain AI agent economy. ([source code](https://github.com/Scottcjn/rustchain))
 
 ### JavaScript
 
@@ -234,7 +233,8 @@
 
 - [Reth](https://github.com/paradigmxyz/reth) - Modular, contributor-friendly and blazing-fast implementation of the Ethereum protocol, in Rust.
 - [OpenEthereum](https://github.com/openethereum/openethereum) - The fast, light, and robust client for the Ethereum mainnet.
-- [RustChain](https://github.com/Scottcjn/Rustchain) - Proof-of-Antiquity blockchain with Ed25519 consensus, GPU attestation channels, and Rust-based miner implementation.
+- [RustChain](https://rustchain.org) - Proof-of-Antiquity blockchain that rewards mining on vintage hardware (PowerPC G4, Pentium 4) with RTC tokens. Features 6-point hardware fingerprinting, Ergo chain anchoring, and an on-chain AI agent economy. ([source code](https://github.com/Scottcjn/rustchain))
+
 ### Shell
 
 - [avash](https://github.com/ava-labs/avash) - Avalanche shell client provides temporary stateful shell execution environment used to deploy networks locally, manage their processes, and run network tests.

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@
 
 - [Reth](https://github.com/paradigmxyz/reth) - Modular, contributor-friendly and blazing-fast implementation of the Ethereum protocol, in Rust.
 - [OpenEthereum](https://github.com/openethereum/openethereum) - The fast, light, and robust client for the Ethereum mainnet.
-
+- [RustChain](https://github.com/Scottcjn/Rustchain) - Proof-of-Antiquity blockchain with Ed25519 consensus, GPU attestation channels, and Rust-based miner implementation.
 ### Shell
 
 - [avash](https://github.com/ava-labs/avash) - Avalanche shell client provides temporary stateful shell execution environment used to deploy networks locally, manage their processes, and run network tests.


### PR DESCRIPTION
## Addition

Adding [RustChain](https://github.com/Scottcjn/Rustchain) to the Rust section.

**RustChain** is a Proof-of-Antiquity blockchain with:
- Ed25519 consensus mechanism
- GPU attestation channels (8 sub-channels)
- Rust-based miner implementation
- Active open-source community with bounty program

### Checklist
- [x] Entry added in alphabetical order within its section
- [x] Description follows the format: `Name - Description`
- [x] Spelling and grammar checked
- [x] One space after the dash