### PR TITLE
Add web3-docs to AI & LLM & MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@
 - [Pythia Oracle MCP](https://github.com/pythia-the-oracle/pythia-oracle-mcp) - On-chain calculated indicators (EMA, RSI, Bollinger, Volatility) for 22 tokens via Chainlink. MCP server + LangChain integration for AI agents to access DeFi data.
 - [Hedera Agent Kit](https://docs.hedera.com/hedera/open-source-solutions/ai-studio-on-hedera/hedera-ai-agent-kit) - Open-source framework for building AI-powered applications that interact with the Hedera Network. Create conversational agents that understand natural language and execute Hedera transactions, or build backend systems that leverage AI for on-chain operations.
 - [Kuberna Labs](https://github.com/kawacukennedy/kuberna-labs) - Decentralized execution rails for AI agents. Deploy TEE-shielded agents to Ethereum, Solana, NEAR with ERC-7683 intents and zkTLS privacy.
+- [web3-docs](https://github.com/dioptx/web3-docs) - Local MCP server with a searchable corpus of 1,767 EIPs, BIPs, ADRs, CIPs, and RFCs across 10 chains plus a canonical contract-address registry covering 19 protocols on major EVM chains. SQLite + FTS5, no API keys.
 
 ## Gas Tracker & Optimization
 


### PR DESCRIPTION
Adds [**web3-docs**](https://github.com/dioptx/web3-docs) to the **AI & LLM & MCP** section.

### What it is
A local MCP server that bundles **1,767 protocol proposals across 10 chains** (EIPs, ERCs, BIPs, SIMDs, Cosmos ADRs, Polkadot RFCs, Stacks SIPs, Avalanche ACPs, Cardano CIPs, Tezos TZIPs, Sui SIPs) plus a **canonical contract-address registry for 19 protocols** on major EVM chains. SQLite + FTS5 — sub-millisecond ranked search, no API keys, works offline.

### Why it fits this list
This section already covers AI agents that read on-chain data (dRPC, Hive, Pythia). web3-docs covers the missing axis: **protocol specifications and canonical addresses**. When an agent needs to answer "what fork shipped PUSH0?", "which BIPs activated with Taproot?", or "what's in Cancun?", it returns the actual upstream spec text instead of a hallucinated paraphrase.

### What's distinctive
- Multi-chain by design (10 chains, not Ethereum-only).
- **Fork-aware**: maps every Ethereum/Bitcoin proposal to its activation fork, with consensus-layer alias support (Pectra ↔ Prague, Dencun ↔ Cancun, Shapella ↔ Shanghai).
- Three demo GIFs in the README cover install, multi-chain contract lookup, and fork drill-down.
- Install: `uvx --from git+https://github.com/dioptx/web3-docs web3-docs-mcp` — works with any MCP-compatible client (Claude Code, Cursor, Windsurf, Cline, Zed, Continue, Codex).

### Rules
- One link per PR ✅
- No "Awesome" in display name ✅
- Section is loose-alphabetical; entry appended at the bottom of `## AI & LLM & MCP` ✅