### PR TITLE
Add Zerion

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,6 +493,7 @@
 - [GoldRush](https://goldrush.dev) - Blockchain data across 100+ chains — wallet balances, token prices, transactions, DEX pairs, and more. REST API, real-time WebSocket with OHLCV price feeds, CLI, and x402 pay-per-request.
 - [Juno](https://juno.build)
 - [Mindlyn](https://mindlyn.io)
+- [Zerion](https://zerion.io/api) - Wallet and DeFi data API across 40+ chains — portfolios, token balances, transactions, NFTs, and DeFi positions. Historical charts, multi-wallet aggregation, and real-time webhooks. Offers CLI, MCP, and pay-per-request via x402 and MPP.
 
 ## Other
 


### PR DESCRIPTION
Adds [Zerion](https://zerion.io/api) to the **Platform as a Service** section.

Zerion provides a wallet and DeFi data API across 40+ chains — portfolios, token balances, transactions, NFTs, and DeFi positions. Includes historical charts, multi-wallet aggregation, real-time webhooks, plus CLI, MCP, and pay-per-request via x402 and MPP.

Entry follows the existing format used by GoldRush in the same section (link + short blurb).