### PR TITLE
Add DeepAlpha to Open Source Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,7 @@
 - [Rainbow](https://github.com/rainbow-me/rainbow) - Open source Ethereum wallet.
 - [Remix](https://github.com/ethereum/remix-project) - Browser-based compiler and IDE that enables users to build Ethereum contracts with Solidity language and to debug transactions.
 - [UniSwap](https://github.com/Uniswap) - Decentralized trading protocol on Ethereum.
+- [DeepAlpha](https://github.com/stefanoviana/deepalpha) - AI-powered crypto trading bot with ML ensemble, 12 exchanges via CCXT, grid trading, and DCA strategies. Open source.
 - [Chainlink](https://github.com/smartcontractkit/chainlink) - Chainlink enhances the possibilities of smart contracts by allowing them to access real-world data.
 - [react-moralis](https://github.com/MoralisWeb3/react-moralis) - Hooks and components to use Moralis in React app.
 - [Solidity](https://github.com/ethereum/solidity) - Solidity is statically typed, contract-oriented, high-level language for implementing smart contracts on the Ethereum platform.


### PR DESCRIPTION
## Description

Adding [DeepAlpha](https://github.com/stefanoviana/deepalpha) to the Open Source Project section.

**DeepAlpha** is an open-source AI-powered crypto trading bot featuring:
- 3-model ML ensemble (XGBoost, LightGBM, CatBoost)
- 12 exchanges supported via CCXT
- Grid trading, DCA with safety orders
- Walk-forward validated
- Python-based with FastAPI dashboard

Fits well alongside other open source Web3 projects like UniSwap and Mobula.

Thank you for maintaining this awesome list!