### PR TITLE
Add evmchain-config to Development Environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@
 
 - [Brownie](https://github.com/eth-brownie/brownie) - Python-based development and testing framework for smart contracts targeting the Ethereum Virtual Machine.
 - [Ethereum Code Viewer](https://github.com/dethcrypto/ethereum-code-viewer) - View source of deployed Ethereum smart contracts in VS Code.
+- [evmchain-config](https://github.com/harunosakura030303-maker/evmchain-config) - Universal EVM chain configuration manager — one `.env` works across Hardhat, Foundry, viem, and ethers. Auto-detects project type, 18+ built-in chains.
 - [EthFiddle](https://ethfiddle.com) - Web-based IDE that lets you write, compile, and debug your smart contract.
 - [Hardhat](https://hardhat.org/) - Development environment to compile, deploy, test, and debug your Ethereum software.
 - [Remix](https://remix.ethereum.org/) - Online IDE for Solidity development.


### PR DESCRIPTION
Adds [evmchain-config](https://github.com/harunosakura030303-maker/evmchain-config) to the Development Environment section.

- Universal EVM chain config manager (Hardhat, Foundry, viem, ethers)
- Auto-detects project type
- 18+ built-in chains with default RPCs
- npm: https://www.npmjs.com/package/evmchain-config