### PR TITLE
Add web3-discover

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,6 +503,7 @@
 - [Ethereum Ecosystem](https://www.ethereum-ecosystem.com/) - Unofficial Ecosystem page for Ethereum and its Layer 2s featuring 900+ dApps and tools across Optimism, Base, Starknet and more.
 - [Formo](https://formo.so) - Web3 forms and product analytics for web3 teams.
 - [SailOnChain](https://sailonchain.com) - Crypto & Web3 job board with 1,400+ positions, salary intelligence, and global remote roles from ~2,000 blockchain companies.
+- [web3-discover](https://web3-discover.vercel.app) - Curated, scam-flagged active airdrop directory across EVM and Solana ecosystems. Hand-vetted entries with deadlines, action steps, cost floor, risk flags, and a "last checked" timestamp per row. No paid listings, no claim-link middlemen.
 
 ## Contribute
 


### PR DESCRIPTION
Adds [web3-discover](https://web3-discover.vercel.app) under the **Other** section, alongside existing directory-style entries like Chainlist, Ethereum Ecosystem, and SailOnChain.

**What it is**: a curated, scam-flagged directory of currently-claimable web3 airdrops across EVM and Solana ecosystems. ~30 hand-vetted entries with deadlines, action steps, cost floor, risk flags, and a "last checked" date stamped per row. No paid listings, no wallet-connect, no claim-link middlemen.

**Why it fits "Other"**: It's a Web3 discovery surface in the same family as Ethereum Ecosystem (dApp directory) or SailOnChain (job directory) — not dev-tooling, not a single project, just a structured catalog with a narrow editorial filter.

**Per CONTRIBUTING.md**:
- One link, one PR ✅
- Title: `Add <repo-name>` format ✅
- Alphabetical placement: `web3-discover` placed after `SailOnChain` in the **Other** section ✅
- Single squashed commit ✅

Thanks for maintaining this list.