### PR TITLE
Add Base Pay Desk

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@
 - [Hugin Messenger - Desktop](https://github.com/kryptokrona/hugin-desktop) - Private messaging application on Kryptokrona Blockchain for desktop.
 - [Hugin Messenger - Mobile](https://github.com/kryptokrona/hugin-mobile) - Private messaging application on Kryptokrona Blockchain for mobile.
 - [Ambire Wallet](https://github.com/AmbireTech/wallet) - Open source Web3 wallet that makes self-custody easy and secure via account abstraction.
+- [Base Pay Desk](https://github.com/oskarasi/base-pay-desk-site) - Non-custodial Base ETH payment-link checkout for creators, agencies, and service sellers with accountless setup intake and transparent platform-fee math.
 - [Mobula](https://github.com/MobulaFi/mobula-ui) - Mobula App is an open-source coin & portfolio tracking platform
 - [Ethui](https://ethui.dev/) - Open-source Ethereum toolkit that integrates wallets, contract explorers, Foundry and Anvil. It streamlines smart contract testing, identity management, and dApp connectivity for developers.
 - [Mybucks.online](https://github.com/mybucks-online/app) - Open-source, browser-based and self-custodial wallet that generates a private key from credentials using one-way hash function.


### PR DESCRIPTION
Adds Base Pay Desk to the Open Source Project section.

Base Pay Desk is a public, non-custodial Base ETH payment-link checkout for creators, agencies, and service sellers. It includes accountless setup intake, setup presets, and transparent platform-fee math.

Checks:
- Searched the README for an existing Base Pay Desk entry; none found.
- Kept this PR to one link.
- Ran `git diff --check`.