### PR TITLE
Add DeFiMath

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@
 ### Solidity
 
 - [Date and Time tools](https://github.com/pipermerriam/ethereum-datetime) - Contract which implements utilities for working with datetime values in ethereum.
-- [DeFiMath](https://defimath.com) - Gas-optimized Solidity library for DeFi math: Black-Scholes option pricing, Greeks, interest rates, and statistics.
+- [DeFiMath](https://github.com/MerkleBlue/defimath) - Gas-optimized Solidity library for DeFi math: Black-Scholes option pricing, Greeks, interest rates, and statistics.
 - [OpenZeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts) - The standard for secure blockchain applications.
 - [CREATE2 Deployer](https://github.com/pcaversaccio/create2deployer) - Helper smart contract to make easier and safer usage of the `CREATE2` EVM opcode.
 - [Solady](https://github.com/Vectorized/solady) - Gas optimized Solidity Libraries.

--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@
 ### Solidity
 
 - [Date and Time tools](https://github.com/pipermerriam/ethereum-datetime) - Contract which implements utilities for working with datetime values in ethereum.
+- [DeFiMath](https://defimath.com) - Gas-optimized Solidity library for DeFi math: Black-Scholes option pricing, Greeks, interest rates, and statistics.
 - [OpenZeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts) - The standard for secure blockchain applications.
 - [CREATE2 Deployer](https://github.com/pcaversaccio/create2deployer) - Helper smart contract to make easier and safer usage of the `CREATE2` EVM opcode.
 - [Solady](https://github.com/Vectorized/solady) - Gas optimized Solidity Libraries.


### PR DESCRIPTION
Adds [DeFiMath](https://defimath.com) to the Solidity section.

DeFiMath is a pure-Solidity, MIT-licensed library of DeFi math primitives — Black-Scholes option pricing (~2,876 gas, ~4.6× cheaper than next-best on-chain implementation), Greeks, implied-volatility solver, interest-rate math, and statistics (volatility, Sharpe, VaR, CVaR, max drawdown). No runtime dependencies.

Inserted alphabetically between `Date and Time tools` and `OpenZeppelin`, per CONTRIBUTING.md.

[Please describe your pull request here]

## Checklist

- [x] The URL is not already present in the list (check with CTRL/CMD+F in the raw markdown file).
- [x] Each description starts with an uppercase character and ends with a period.<br>Example: `solc-js - JavaScript bindings for the compiler.`
- [x] Drop all `A` / `An` prefixes at the start of the description.
