### PR TITLE
Add TWZRD Agent Intel to AI & LLM & MCP section

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@
 - [web3-docs](https://github.com/dioptx/web3-docs) - Local MCP server with a searchable corpus of 1,767 EIPs, BIPs, ADRs, CIPs, and RFCs across 10 chains plus a canonical contract-address registry covering 19 protocols on major EVM chains. SQLite + FTS5, no API keys.
 - [Assay Protocol](https://github.com/Grandionn/assay-protocol) - Economic trust enforcement for AI agents on Base. USDC staking, outcome-verified escrow, algorithmic reputation scoring (0-1000), and semantic discovery for ERC-8004 agents. 2000+ agents indexed. ([npm](https://www.npmjs.com/package/@assaylabs/trust-check))
 - [Web3 Agent Kit](https://github.com/ulsreall/web3-agent-kit) - Open-source Python framework for building autonomous AI agents that interact with DeFi protocols. Multi-chain support (Ethereum, Base, Arbitrum, Optimism, Polygon), LLM-powered reasoning (OpenAI, Anthropic, Groq, DeepSeek), Uniswap V2 swaps, cross-chain bridges (Li.Fi, Socket), token sniper, and portfolio tracking.
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - Trust-scoring MCP server for x402 agents on Solana. Free on-chain preflight checks trust + identity signals; signed trust receipt via USDC micropayment (<$0.01, <1s settlement). MCP: `https://intel.twzrd.xyz/mcp`
 
 ## Gas Tracker & Optimization
 


### PR DESCRIPTION
## Summary

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the **AI & LLM & MCP** section.

**What is it**: Trust-scoring MCP server for x402 agents on Solana.
- **Free preflight**: On-chain checks for wallet trust + identity signals
- **Paid receipt**: Signed USDC trust receipt (<$0.01, <1s settlement)
- **MCP URL**: `https://intel.twzrd.xyz/mcp` (Streamable-HTTP)

This fits naturally alongside existing AI agent tools in the section, adding Solana-native trust verification for the growing x402 agent economy.