### PR TITLE
Add TWZRD Agent Intel: x402-powered MCP trust infrastructure for AI agents on Solana

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@
 - [MoltsPay](https://github.com/Yaqing2023/moltspay) - Universal Payment Protocol (UPP) for AI agents that abstracts multiple underlying protocols (x402, MPP, PFS, Pre-Approval) into a single unified API. Supports 8 blockchains with protocol-specific optimizations and gasless payments. Node.js and Python SDKs available.
 - [x402-proxy](https://github.com/cascade-protocol/x402-proxy) - `curl` for x402 paid APIs. CLI and library that auto-pays HTTP 402 responses with USDC on Base and Solana, with MCP stdio proxy for AI agents.
 - [@up2itnow0822/agent-wallet-sdk](https://github.com/up2itnow0822/agent-wallet-sdk) - TypeScript SDK for non-custodial AI agent wallets. Handles x402 payments, CCTP V2 cross-chain transfers, Uniswap V3 token swaps, and on-chain spend limits. MIT license.
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - MCP server providing on-chain trust scoring for AI agents operating with Solana payments. Tools: `resolve_agent`, `score_agent`, `preflight_check`, `verify_trust_receipt` (free) and `get_trust_receipt` (paid via x402 USDC, <1s Solana settlement). Zero-install: `{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}`
 
 ## AI & LLM & MCP
 


### PR DESCRIPTION
Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) — MCP server providing on-chain trust scoring for AI agents operating with Solana payments.

AI agents call \`preflight_check\` before dispatching transactions, \`score_agent\` to query trust scores, and \`get_trust_receipt\` to mint a signed V5 receipt (paid via x402 USDC micropayment, <1s Solana settlement).

Zero-install: \`{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}\`

Added to the **x402 Payments Protocol** section as it is a direct x402-powered tool: the paid \`get_trust_receipt\` tool uses HTTP 402 / x402 USDC micropayment on Solana for sub-second receipt minting. The free tools (\`resolve_agent\`, \`score_agent\`, \`preflight_check\`, \`verify_trust_receipt\`) are also useful for any agent integrating with Solana.