### PR TITLE
Add OpenChainBench

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@
 
 - [Codex](https://www.codex.io) - Blockchain data API for accessing on-chain data across multiple networks.
 - [Indexed.xyz](https://indexed.xyz) - Raw and decoded logs, transactions, and blocks for many EVM chains.
+- [OpenChainBench](https://openchainbench.com) - Open, reproducible benchmarks for crypto infrastructure (aggregators, bridges, blockchains, perps) with live data, public methodology, and a JSON API. Data is CC-BY-4.0.
 - [Ormi Labs](https://ormilabs.com) - Ormi's 0xgraph is a next-gen subgraph indexing platform delivering 5× faster syncs, real-time queries with sub-second latency, zero throttling, and built-in support for chain re-orgs across 70+ chains.
 
 ### Risk Management


### PR DESCRIPTION
Adds OpenChainBench under Datasets, in alphabetical order. Open source (MIT, TypeScript) benchmarks for crypto infrastructure with live data refreshed every 60s, public methodology, and a public JSON API. Data is CC-BY-4.0. Site: https://openchainbench.com, repo: https://github.com/ChainBench/OpenChainBench.

## Checklist

- [x] The URL is not already present in the list (check with CTRL/CMD+F in the raw markdown file).
- [x] Each description starts with an uppercase character and ends with a period.<br>Example: `solc-js - JavaScript bindings for the compiler.`
- [x] Drop all `A` / `An` prefixes at the start of the description.