### PR TITLE
Add Clawdbot by Suede Labs AI — x402 music IP licensing agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@
 - [MoltsPay](https://github.com/Yaqing2023/moltspay) - Universal Payment Protocol (UPP) for AI agents that abstracts multiple underlying protocols (x402, MPP, PFS, Pre-Approval) into a single unified API. Supports 8 blockchains with protocol-specific optimizations and gasless payments. Node.js and Python SDKs available.
 - [x402-proxy](https://github.com/cascade-protocol/x402-proxy) - `curl` for x402 paid APIs. CLI and library that auto-pays HTTP 402 responses with USDC on Base and Solana, with MCP stdio proxy for AI agents.
 - [@up2itnow0822/agent-wallet-sdk](https://github.com/up2itnow0822/agent-wallet-sdk) - TypeScript SDK for non-custodial AI agent wallets. Handles x402 payments, CCTP V2 cross-chain transfers, Uniswap V3 token swaps, and on-chain spend limits. MIT license.
+- [Clawdbot by Suede Labs AI](https://suedeai.ai) - Virtuals ACP agent on Base with 17 x402-gated HTTP 402 endpoints for music IP licensing. AI agents pay musicians in real time for licensed creative work; bridges on-chain IP registration ($SUEDE Solana/Base) with agentic micropayments ($SVID: `0x2aed2c4dCB3D61938e36f3481dEFE553fac0ADbd`).
 
 ## AI & LLM & MCP
 


### PR DESCRIPTION
## Add to x402 Payments Protocol section

**Clawdbot by Suede Labs AI** (https://suedeai.ai) — Virtuals ACP agent on Base with **17 x402-gated HTTP 402 endpoints** for music IP licensing.

AI agents pay musicians in real time for licensed creative work using the x402 protocol. It bridges:
- On-chain IP registration ($SUEDE token: Solana + Base)
- Agentic micropayments ($SVID: `0x2aed2c4dCB3D61938e36f3481dEFE553fac0ADbd` on Base 8453)
- Virtuals ACP protocol (agent commerce marketplace)

This is a domain-specific application of x402 to the music creator economy — similar to Signet/Arch Tools but for licensed music content delivery. Fits cleanly after the existing x402 entries.

Links: [suedeai.ai](https://suedeai.ai) · [@AISUEDE](https://x.com/AISUEDE) · [t.me/SUEDEAI](https://t.me/SUEDEAI) · [CoinGecko](https://www.coingecko.com/en/coins/johnny-suede)