### PR TITLE
Add TRONSEC

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@
 - [Web3 Antivirus](https://web3antivirus.io) - Browser extension simulating transactions and reporting risks for user-side defense.
 - [PolicyLayer](https://policylayer.com) - Non-custodial spending controls for AI agents with crypto wallets. Enforce daily limits, per-transaction caps, and recipient whitelists without holding private keys.
 - [Sharpe Rug Check](https://www.sharpe.ai/rug-check) - Free token safety scanner and rug pull checker with a 0-100 risk score across Solana, Ethereum, Base, BSC, Arbitrum, and Polygon. Honeypot simulation, mint-authority detection, liquidity-lock verification, and holder-concentration analysis. No signup, public REST API.
+- [TRONSEC](https://tronsec.io/app/) - Client-side TRON security toolkit: wallet analysis, AML heuristics, contract scanning, transaction decoding, and phishing URL checks. No wallet connection required. [Source](https://github.com/jamejohns/tronsec).
 
 ### x402 Payments Protocol
 


### PR DESCRIPTION
## Summary

Adds TRONSEC to **Risk Management** — a free, read-only security terminal for the TRON blockchain.

## Tool

- **URL:** https://tronsec.io/app/
- **Source:** https://github.com/jamejohns/tronsec

TRONSEC runs entirely in the browser: paste a TRON address, contract, transaction hash, or URL and get structured risk signals (wallet scanner, AML heuristics, contract audit signals, TX decoder, URL/phishing checks). No wallet connect, no account.

## Fit

Similar audience to Sharpe Rug Check and Web3 Antivirus — end-user / researcher risk tooling. TRON-specific; complements the mostly EVM-focused entries in this section.

## Checklist

- [x] One link per PR (CONTRIBUTING)
- [x] Alphabetical order in Risk Management
- [x] PR title: `Add TRONSEC`
- [x] Single commit