### PR TITLE
Add AgentsCoin to AI & LLM & MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,7 @@
 - [web3-docs](https://github.com/dioptx/web3-docs) - Local MCP server with a searchable corpus of 1,767 EIPs, BIPs, ADRs, CIPs, and RFCs across 10 chains plus a canonical contract-address registry covering 19 protocols on major EVM chains. SQLite + FTS5, no API keys.
 - [Assay Protocol](https://github.com/Grandionn/assay-protocol) - Economic trust enforcement for AI agents on Base. USDC staking, outcome-verified escrow, algorithmic reputation scoring (0-1000), and semantic discovery for ERC-8004 agents. 2000+ agents indexed. ([npm](https://www.npmjs.com/package/@assaylabs/trust-check))
 - [Web3 Agent Kit](https://github.com/ulsreall/web3-agent-kit) - Open-source Python framework for building autonomous AI agents that interact with DeFi protocols. Multi-chain support (Ethereum, Base, Arbitrum, Optimism, Polygon), LLM-powered reasoning (OpenAI, Anthropic, Groq, DeepSeek), Uniswap V2 swaps, cross-chain bridges (Li.Fi, Socket), token sniper, and portfolio tracking.
+- [AgentsCoin](https://github.com/axiosdevs/agentscoin-mcp) - Give your AI agent its own money on a live EVM chain (chainId 24368): wallet, faucet, send, and create/trade tokens via MCP.
 
 ## Gas Tracker & Optimization
 


### PR DESCRIPTION
Adds AgentsCoin to the **AI & LLM & MCP** section.

AgentsCoin is a live EVM chain (chainId 24368) that gives AI agents their own money via an MCP server (9 tools: wallet, faucet, send, create/trade tokens).

- MCP server: https://github.com/axiosdevs/agentscoin-mcp (npm `agentscoin-mcp`, remote https://agents-coin.com/mcp)
- Site: https://agents-coin.com

One entry added, alphabetical-list format matched, placed at the end of the section.