### PR TITLE
Add sunwatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,6 +496,7 @@
 - [GetBlock](https://getblock.io/)
 - [Ankr](https://www.ankr.com/)
 - [SimpleHash](https://simplehash.com)
+- [sunwatch](https://sunwatch.sunfamily.xyz) - Crypto-paid uptime monitoring for side projects. Pay per monitor in USDC on Base with no accounts or KYC.
 - [walletOS](https://www.pinestreetlabs.com/walletos/)
 - [Tenderly](https://tenderly.co)
 - [Apillon](https://apillon.io/)


### PR DESCRIPTION
[sunwatch](https://sunwatch.sunfamily.xyz) is a crypto-paid uptime monitor for side projects.\n\n- Pay per monitor with USDC on Base\n- No accounts, no KYC, no subscription lock-in\n- Webhook alerts on down/up state changes\n\nAdded to the Platform as a Service section alphabetically.