### PR TITLE
Add CryptoAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@
 - [Sharpe Rug Check](https://www.sharpe.ai/rug-check) - Free token safety scanner and rug pull checker with a 0-100 risk score across Solana, Ethereum, Base, BSC, Arbitrum, and Polygon. Honeypot simulation, mint-authority detection, liquidity-lock verification, and holder-concentration analysis. No signup, public REST API.
 - [TRONSEC](https://tronsec.io/app/) - Client-side TRON security toolkit: wallet analysis, AML heuristics, contract scanning, transaction decoding, and phishing URL checks. No wallet connection required. [Source](https://github.com/jamejohns/tronsec).
 - [OnChainRisk](https://onchainrisk.io/) - Wallet, token, and smart-contract risk scoring API for Web3 teams; surfaces risk signals such as malicious-token patterns, fund-flow exposure, counterparties, and labels.
+- [CryptoAML](https://cryptoaml.ai) - Free multi-chain AML wallet screening via Telegram bot ([@cryptoamlscan_bot](https://t.me/cryptoamlscan_bot)) and web. Screens against OFAC/UN/EU sanctions, darknet markets, mixers, and scam databases across 30+ chains. No registration required.
 
 ### x402 Payments Protocol
 


### PR DESCRIPTION
## Description

Adding [CryptoAML](https://cryptoaml.ai) to the Risk Management section, alongside TRONSEC and OnChainRisk.

**CryptoAML** is a free AML wallet screening tool:
- Available as a Telegram bot ([@cryptoamlscan_bot](https://t.me/cryptoamlscan_bot)) and web interface (cryptoaml.ai)
- Screens against OFAC, UN, and EU sanctions lists, darknet markets, mixers, and scam databases
- Covers 30+ chains (BTC, ETH, TRON, BNB Chain, and more)
- No registration required

Follows the existing format used by other Risk Management entries (single link + one-line description).