### PR TITLE
Add testnetfaucets.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@
 - [Solana Playground](https://github.com/solana-playground/solana-playground) - Online IDE to quickly develop and deploy Solana programs that runs on web browser.
 - [Tenderly DevNets](https://docs.tenderly.co/devnets/intro-to-devnets) - Development Networks or DevNets are a zero-setup, managed development environment for developing, testing, and debugging smart contracts. With built-in debugging tools, DevNets eliminate the need to run any third-party software or to set up an environment.
 - [RevX](https://revx.dev/) - Online IDE for developing, compile, deploy, and test contracts on Polkadot.
+- [testnetfaucets.dev](https://testnetfaucets.dev) - Live status dashboard for 36 testnet faucets across 30+ networks, health-checked daily so you know which faucet works before you start testing.
 
 ### DevOps
 


### PR DESCRIPTION
Adds **testnetfaucets.dev**, a free, open-source live status dashboard that health-checks 36 blockchain testnet faucets across 30+ networks (Sepolia, Solana, BTC, Polygon Amoy, Avalanche Fuji, Sui, Aptos, Sei...) daily and reports which are up, down, or moved.

Added as a single entry at the end of the Development Environment subsection. Happy to move it to a more fitting section (or a dedicated Testnets/Faucets one) if you'd prefer.

Source: https://github.com/aleksandralukic/faucet-app