### PR TITLE
Add browser-web3-signer

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@
 - [Reth](https://github.com/paradigmxyz/reth) - Modular, contributor-friendly and blazing-fast implementation of the Ethereum protocol, in Rust.
 - [OpenEthereum](https://github.com/openethereum/openethereum) - The fast, light, and robust client for the Ethereum mainnet.
 - [RustChain](https://rustchain.org) - Proof-of-Antiquity blockchain that rewards mining on vintage hardware (PowerPC G4, Pentium 4) with RTC tokens. Features 6-point hardware fingerprinting, Ergo chain anchoring, and an on-chain AI agent economy. ([source code](https://github.com/Scottcjn/rustchain))
+- [browser-web3-signer](https://github.com/nikicat/browser-web3-signer) - Sign EVM and TRON transactions and messages with your own browser wallet (MetaMask, Rabby, TronLink) from the CLI or from Rust, TypeScript, and Go programs; the private key never leaves the browser.
 
 ### Shell
 


### PR DESCRIPTION
Adds [browser-web3-signer](https://github.com/nikicat/browser-web3-signer) to the Software Development → Rust section.

A Rust CLI + Rust/TypeScript/Go libraries to sign EVM and TRON transactions and messages using your own browser wallet (MetaMask, Rabby, TronLink). A localhost-only bridge opens an approval page in the browser; the private key never leaves the wallet extension. MIT licensed, published on crates.io, npm, and as a Go module.

Follows the contribution guidelines: one link, single squashed commit, appended in the style of the section.