### PR TITLE
Add OpenChainBench to DevOps section

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@
 
 - [Cannon](https://usecannon.com/) - Continuous configuration automation & development cli multi-tool. Like Terraform, Docker and NPM for Ethereum.
 - [Catapulta](https://catapulta.sh) - Zero config multi-chain smart contracts platform, for Foundry and Hardhat. Deploy smart contracts, we cover the gas for you in +20 EVM networks.
+- [OpenChainBench](https://openchainbench.com) - Independent open-source benchmarks for RPC providers, L2 finality, gas oracles, and archive coverage across 22 chains. Data ships under CC BY 4.0, harnesses in Go/Rust on GitHub.
 
 ### Hosting
 


### PR DESCRIPTION
## Summary

Adds [OpenChainBench](https://openchainbench.com) to the **Software Development → DevOps** section.

## Why it fits

DevOps for Web3 stacks depends heavily on picking reliable RPC providers, gas oracles, and monitoring the archive coverage needed for indexers and analytics. OpenChainBench publishes continuous, independent measurements of these across 22 chains from three regions:

- RPC latency (p50/p95/p99) and error classification per (provider × chain)
- L2 finality timing
- Gas oracle accuracy vs on-chain reality
- Archive depth coverage (which providers gate historical calls behind paid tiers)
- Anti cache probe design so measurements reflect real node work

All data is CC BY 4.0, methodology is public, harnesses are open-source Go/Rust on GitHub, and the site itself is neutral (no chain foundation or RPC provider affiliation).

## Change

One line added to the DevOps section alphabetically after `Catapulta`. No other changes.