### PR TITLE
Add AtlasYield to Datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@
 
 ### Datasets
 
+- [AtlasYield](https://atlasyield.club) - Independent rating and allocation layer for on-chain yield — scores every DeFi vault 0-100 across 16 factors.
 - [Codex](https://www.codex.io) - Blockchain data API for accessing on-chain data across multiple networks.
 - [Indexed.xyz](https://indexed.xyz) - Raw and decoded logs, transactions, and blocks for many EVM chains.
 - [OpenChainBench](https://openchainbench.com) - Open, reproducible benchmarks for crypto infrastructure (aggregators, bridges, blockchains, perps) with live data, public methodology, and a JSON API. Data is CC-BY-4.0.


### PR DESCRIPTION
AtlasYield (atlasyield.club) is an independent rating and allocation layer for on-chain yield: scores every DeFi vault 0-100 across 16 factors / 4 pillars, 584 vaults daily across 8 protocols and 5 chains. Read-only public API at api.atlasyield.club/v1. Added alphabetically to Datasets.