### PR TITLE
Add contract::rw

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@
 - [Tenderly DevNets](https://docs.tenderly.co/devnets/intro-to-devnets) - Development Networks or DevNets are a zero-setup, managed development environment for developing, testing, and debugging smart contracts. With built-in debugging tools, DevNets eliminate the need to run any third-party software or to set up an environment.
 - [RevX](https://revx.dev/) - Online IDE for developing, compile, deploy, and test contracts on Polkadot.
 - [testnetfaucets.dev](https://testnetfaucets.dev) - Live status dashboard for 36 testnet faucets across 30+ networks, health-checked daily so you know which faucet works before you start testing.
+- [contract::rw](https://contractrw.dev) - Browser console to read and write any EVM contract from an ABI, on any chain or custom RPC including a local anvil/hardhat node. Decodes revert errors, function selectors and calldata. No verified source or signup needed.
 
 ### DevOps
 


### PR DESCRIPTION
Adds **contract::rw**, a free browser console for reading and writing EVM smart contracts from an ABI. Unlike explorer-based interaction it doesn't need verified source or an uploaded ABI — paste an address + ABI, point it at any chain or a custom RPC (including a local anvil/hardhat node), and call read functions or send write transactions. It also decodes revert errors against the ABI's custom errors and includes a 4-byte selector lookup and calldata decoder. Reads need no wallet; everything runs client-side, no signup or backend.

Added as a single entry at the end of the Development Environment subsection, matching how the recent entries there were added. Happy to move it to another section if you'd prefer. I'm the author.

## Checklist

- [x] The URL is not already present in the list (check with CTRL/CMD+F in the raw markdown file).
- [x] Each description starts with an uppercase character and ends with a period.<br>Example: `solc-js - JavaScript bindings for the compiler.`
- [x] Drop all `A` / `An` prefixes at the start of the description.
