### PR TITLE
Add ChainJobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,6 +523,7 @@
 
 ## Other
 
+- [ChainJobs](https://chainjobs.io) - Crypto & web3 job board with 2,650+ live roles aggregated daily from companies' official ATS systems, employer-published salary data, free JSON API.
 - [Chainlist](https://chainlist.org) - List of EVM networks, Chain IDs and Network IDs.
 - [Crypto Payroll](https://www.request.finance/payroll) - Automate and simplify payroll operations in crypto.
 - [Ethereum Ecosystem](https://www.ethereum-ecosystem.com/) - Unofficial Ecosystem page for Ethereum and its Layer 2s featuring 900+ dApps and tools across Optimism, Base, Starknet and more.


### PR DESCRIPTION
Adding **ChainJobs** (https://chainjobs.io) — a crypto/web3 job board with a different source model from the boards already listed:

- 2,650+ live roles across 120 companies, re-scraped **daily from companies' own official ATS boards** (Greenhouse/Lever/Ashby) — no reposts; roles auto-expire when closed at the source
- 470+ roles with **employer-published salary bands** (medians/percentiles at /crypto-salaries/, nothing estimated)
- Free to browse, no signup wall; every listing links to the employer's own application page
- Free JSON API + RSS feeds
- Non-technical roles (marketing/BD/community/ops) surfaced alongside engineering

Link verified live; entry follows the list's format and position conventions. Happy to adjust wording.
