### PR TITLE
Add n8n Solana Price Alert to No Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@
 - [ChainJet](https://chainjet.io) - No-code platform for building on-chain or off-chain task automations. Use ChainJet to integrate multiple web3 services to automate all kinds of tasks.
 - [Layer4](https://www.layer4.app) - No-code and low-code blockchain integration platform. Deploy standard token contracts or persist data on-chain with a few clicks.
 - [WalletConnect](https://novabloq.com/plugin/walletconnect-official-1671213284712x803510314952042000) - Web3Modal v2 SDK with updated UI integrated into a plugin for bubble.io - Connect a wallet, sign a message, detect chain or account changed.
+- [n8n Solana Price Alert](https://github.com/DeusAcc/n8n-solana-price-alert) - Free, no-code n8n workflow that alerts on Telegram when a Solana SPL token price crosses a threshold, no external database needed.
 
 ### Boilerplate
 


### PR DESCRIPTION
Adds one link under No Code: a free, no-code n8n workflow that alerts on Telegram when a Solana SPL token price crosses a threshold. No external database.

Source: https://github.com/DeusAcc/n8n-solana-price-alert (MIT licensed, tested working).