### PR TITLE
Add Vultisig

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@
 - [Pact](https://github.com/manja316/pact-escrow) - Trustless freelance escrow on Base. Lock funds in a smart contract, release on milestone completion.
 - [Drift](https://github.com/manja316/drift-subscriptions) - Onchain subscription payments on Base. Recurring crypto payments with auto-debit smart contracts.
 - [Vaultion](https://github.com/troysteele5-dotcom/vaultion-contracts) - Non-custodial crypto escrow for stablecoin deals. Funds lock in an open-source smart contract and release on agreement or by dispute ruling.
+- [Vultisig](https://github.com/vultisig/vultisig-windows) - Seedless self-custodial multi-chain wallet secured by MPC threshold signatures; this repo builds the Vultisig desktop app and the Chrome extension.
 
 ## Tutorial
 


### PR DESCRIPTION
Vultisig is an open-source multi-chain wallet with no seed phrase — key generation and signing run as MPC threshold signatures split across the user's own devices, so the full private key is never assembled in one place.

The linked repo is the shared TypeScript codebase behind the desktop app and the Chrome extension (Apache-2.0); the extension registers via EIP-6963 as `me.vultisig` for dApp connections. Fits alongside the other open-source wallet entries in this section. One link, appended at the end to match how the section is currently ordered, commits squashed.

Docs-only addition — no runtime changes.
