### PR TITLE
Add RektCalc

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@
 - [Sharpe Rug Check](https://www.sharpe.ai/rug-check) - Free token safety scanner and rug pull checker with a 0-100 risk score across Solana, Ethereum, Base, BSC, Arbitrum, and Polygon. Honeypot simulation, mint-authority detection, liquidity-lock verification, and holder-concentration analysis. No signup, public REST API.
 - [TRONSEC](https://tronsec.io/app/) - Client-side TRON security toolkit: wallet analysis, AML heuristics, contract scanning, transaction decoding, and phishing URL checks. No wallet connection required. [Source](https://github.com/jamejohns/tronsec).
 - [OnChainRisk](https://onchainrisk.io/) - Wallet, token, and smart-contract risk scoring API for Web3 teams; surfaces risk signals such as malicious-token patterns, fund-flow exposure, counterparties, and labels.
+- [RektCalc](https://rektcalc.com/) - Free crypto leverage risk calculators: liquidation price, position sizing, funding rate carry, and a 0-100 shareable Rekt Risk Score for any trade. No signup.
 
 ### x402 Payments Protocol
 


### PR DESCRIPTION
Adds [RektCalc](https://rektcalc.com/) to the Risk Management section — free crypto leverage/futures risk calculators (liquidation price, position sizing, funding rate carry) plus a 0-100 shareable Rekt Risk Score, in the spirit of the existing Sharpe Rug Check / OnChainRisk entries. No signup, browser-only.