### PR TITLE
Add usdctofiat-offramp

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@
 - [Kryptokrona Kotlin SDK](https://github.com/kryptokrona/kryptokrona-kotlin-sdk) - Kryptokrona SDK in Kotlin for building decentralized private communication and payment systems.
 - [PVP Genesis SDK](https://github.com/Synapse-Founder/pvp-genesis-sdk) - TypeScript/JavaScript SDK for tokenizing physical energy and compute resources on Polygon blockchain, enabling DePIN applications.
 - [Tatum SDK](https://github.com/tatumio/tatum-js) - Tatum SDK is a powerful, feature-rich TypeScript/JavaScript library that streamlines the development of blockchain applications.
+- [USDCtoFiat Offramp](https://github.com/ADWilkinson/galleonlabs-zkp2p/tree/main/packages/offramp-sdk) - TypeScript SDK for non-custodial USDC-to-fiat on Base. One call: `cashout({ mode: "fast" | "best" })`. Direct rails Revolut, Monzo, Chime, Zelle.
 - [Clanker Wallet](https://github.com/almogdepaz/clanker-wallet) - Human-approved blockchain transactions for AI agents. Agent proposes a tx, human reviews and signs from a web app. E2E encrypted, CLI + TypeScript + Python SDKs.
 - [AxonFi SDK](https://github.com/axonfi/sdk) - Non-custodial treasury and payment SDK for AI agents. Agents sign EIP-712 intents from secure vaults without holding funds or paying gas. TypeScript, Python, and LangChain integrations. Multi-chain (Base, Arbitrum).
 - [Hypermid SDK](https://github.com/Hypermid) - Cross-chain swap, bridge & fiat on-ramp SDK across 90+ chains (EVM, Solana, Bitcoin, NEAR, Sui, Tron, TON). Available in TypeScript, Python, Go and Rust. Anonymous tier — no API key required.


### PR DESCRIPTION
USDCtoFiat Offramp under SDK. One link.

https://github.com/ADWilkinson/galleonlabs-zkp2p/tree/main/packages/offramp-sdk

## Checklist

- [x] The URL is not already present in the list (check with CTRL/CMD+F in the raw markdown file).
- [x] Each description starts with an uppercase character and ends with a period.
- [x] Drop all `A` / `An` prefixes at the start of the description.
