### PR TITLE
Add Cyrus Relay to x402 Payments Protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,8 @@
 - [x402-proxy](https://github.com/cascade-protocol/x402-proxy) - `curl` for x402 paid APIs. CLI and library that auto-pays HTTP 402 responses with USDC on Base and Solana, with MCP stdio proxy for AI agents.
 - [@up2itnow0822/agent-wallet-sdk](https://github.com/up2itnow0822/agent-wallet-sdk) - TypeScript SDK for non-custodial AI agent wallets. Handles x402 payments, CCTP V2 cross-chain transfers, Uniswap V3 token swaps, and on-chain spend limits. MIT license.
 - [SpraayBatch](https://github.com/plagtech/SpraayBatch) - Batch USDC payments on Base for AI agents — pay up to 200 recipients in one atomic transaction. Gasless via CDP Paymaster, non-custodial auto-wallets, per-agent budget caps. OpenClaw plugin with ClawHub security audit pass. ([ClawHub](https://clawhub.ai/plagtech/plugins/spraay-batch))
-- [AgentServices](https://github.com/vbkotecha/aiservices-api) - 54 services / 97 endpoints with 37 MCP tools: crypto prices, OHLCV, DeFi yields, technical indicators, DEX swap quotes, prediction markets, trending tokens, gas tracker, and on-chain analytics. 41 x402-paid endpoints ($0.01-$0.05/call, USDC on Base). Remote MCP server, cloud-hosted.
+- [AgentServices](https://github.com/vbkotecha/aiservices-api) - 54 services / 97 endpoints with 37 MCP tools: crypto prices, OHLCV, DeFi yields, technical indicators, DEX swap quotes, prediction markets, trending tokens, gas tracker, and on-chain analytics. 41 x402-paid endpoints ($0.01-$0.05/call, USDC on Base). Remote MCP server (TypeScript, cloud-hosted).
+- [Cyrus Relay](https://github.com/ghassan-gaidi/cyrus-relay) - OpenAI-compatible LLM gateway with per-request USDC pricing via the x402 protocol on Base, Arbitrum, and Polygon. MIT reference implementation; ships with a Telegram bot (@hetsvdbot). ([Release v1.0](https://github.com/ghassan-gaidi/cyrus-relay/releases/tag/v1.0-paid-bot) | [Landing](https://ghassan-gaidi.github.io/cyrus-relay/))
 
 ## AI & LLM & MCP
 

--- a/README.md
+++ b/README.md
@@ -350,8 +350,8 @@
 - [x402-proxy](https://github.com/cascade-protocol/x402-proxy) - `curl` for x402 paid APIs. CLI and library that auto-pays HTTP 402 responses with USDC on Base and Solana, with MCP stdio proxy for AI agents.
 - [@up2itnow0822/agent-wallet-sdk](https://github.com/up2itnow0822/agent-wallet-sdk) - TypeScript SDK for non-custodial AI agent wallets. Handles x402 payments, CCTP V2 cross-chain transfers, Uniswap V3 token swaps, and on-chain spend limits. MIT license.
 - [SpraayBatch](https://github.com/plagtech/SpraayBatch) - Batch USDC payments on Base for AI agents — pay up to 200 recipients in one atomic transaction. Gasless via CDP Paymaster, non-custodial auto-wallets, per-agent budget caps. OpenClaw plugin with ClawHub security audit pass. ([ClawHub](https://clawhub.ai/plagtech/plugins/spraay-batch))
-- [AgentServices](https://github.com/vbkotecha/aiservices-api) - 54 services / 97 endpoints with 37 MCP tools: crypto prices, OHLCV, DeFi yields, technical indicators, DEX swap quotes, prediction markets, trending tokens, gas tracker, and on-chain analytics. 41 x402-paid endpoints ($0.01-$0.05/call, USDC on Base). Remote MCP server (TypeScript, cloud-hosted).
-- [Cyrus Relay](https://github.com/ghassan-gaidi/cyrus-relay) - OpenAI-compatible LLM gateway with per-request USDC pricing via the x402 protocol on Base, Arbitrum, and Polygon. MIT reference implementation; ships with a Telegram bot (@hetsvdbot). ([Release v1.0](https://github.com/ghassan-gaidi/cyrus-relay/releases/tag/v1.0-paid-bot) | [Landing](https://ghassan-gaidi.github.io/cyrus-relay/))
+- [AgentServices](https://github.com/vbkotecha/aiservices-api) - 54 services / 97 endpoints with 37 MCP tools: crypto prices, OHLCV, DeFi yields, technical indicators, DEX swap quotes, prediction markets, trending tokens, gas tracker, and on-chain analytics. 41 x402-paid endpoints (USDC on Base). Remote MCP server (TypeScript, cloud-hosted).
+- [Cyrus Relay](https://github.com/ghassan-gaidi/cyrus-relay) - OpenAI-compatible LLM gateway with per-request USDC pricing via the x402 protocol on Base, Arbitrum, and Polygon.
 
 ## AI & LLM & MCP
 


### PR DESCRIPTION
## Add Cyrus Relay

**What:** Cyrus Relay is an OpenAI-compatible LLM API gateway that charges per request in USDC via the x402 protocol (Base, Arbitrum, Polygon). MIT-licensed reference implementation with a public gateway, GitHub Pages landing, and a Telegram bot (@hetsvdbot).

**Why:** Useful working example of an x402-monetized HTTP service for the Web3 community — transparent wallet, transparent release, transparent codebase. Fits the existing `x402 Payments Protocol` subsection directly.

**Quality Checklist:**
- [x] Actively maintained — v1.0-paid-bot release dated 2026-08-30
- [x] Well-documented — landing page, repo README, release notes, gist overview
- [x] Directly related to x402 (USDC settlement over HTTP 402)
- [x] Link working: https://github.com/ghassan-gaidi/cyrus-relay
- [x] No marketing fluff; neutral descriptive tone

**Verifiable artifacts:**
- Repo: https://github.com/ghassan-gaidi/cyrus-relay
- Release: https://github.com/ghassan-gaidi/cyrus-relay/releases/tag/v1.0-paid-bot
- Landing: https://ghassan-gaidi.github.io/cyrus-relay/
- Gateway: https://example-losing-dimension-assisted.trycloudflare.com
- Overview gist: https://gist.github.com/ghassan-gaidi/06a4a6b76b7c3d5f732a28e3b45d84c2
- Wallet (Base/Arb/Pol USDC): `0xF9EDF0052A39D8b1D50780a7227a203Ba3b557f9`
- Telegram bot: @hetsvdbot