### PR TITLE
Add FlexYield

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@
 ## AI & LLM & MCP
 
 - [dRPC Agent Skills](https://github.com/drpcorg/drpc-agent-skills) - Read-only on-chain data for AI agents via DRPC's node network. Covers all major EVM networks and Solana. Free API key at drpc.org.
+- [FlexYield](https://flexyield.io/mcp) - Blockchain RPC gateway with a hosted MCP server: one API key across Ethereum, Base, Arbitrum, Optimism, Polygon and Solana, multi-provider failover, per-key budgets for agent fleets, measured reliability. Free tier 1M req/mo.
 - [Hive Intelligence](https://github.com/hive-intel/hive-crypto-mcp) 🎖️ 📇 ☁️ 🏠 - Institutional-grade crypto market infrastructure for AI — live prices, DeFi, wallets, and token risk through a managed MCP, REST API, or CLI.
 - [Hashgraph Online (HOL)](https://github.com/hashgraph-online) - Universal agentic registry on Hedera providing blockchain-based identity for AI agents via HCS-14 Universal Agent IDs (UAIDs). Bridges A2A, ERC-8004, x402, and MCP protocols. 187K+ verified agents, 33M+ daily operations. Open-source SDKs: TypeScript, Go, Python.
 - [Pythia Oracle MCP](https://github.com/pythia-the-oracle/pythia-oracle-mcp) - On-chain calculated indicators (EMA, RSI, Bollinger, Volatility) for 22 tokens via Chainlink. MCP server + LangChain integration for AI agents to access DeFi data.


### PR DESCRIPTION
Adds FlexYield to **AI & LLM & MCP**: a blockchain RPC gateway with a hosted MCP server (https://flexyield.io/mcp) — one API key across Ethereum, Base, Arbitrum, Optimism, Polygon and Solana with automatic multi-provider failover, per-key budgets for agent fleets, and a public status page with measured uptime/latency. Free tier: 1M requests/month, no card. Docs: https://flexyield.io/docs · machine-readable: https://flexyield.io/llms.txt

One link, alphabetical within the section, single commit.