### PR TITLE
Add PublicAML to Risk Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@
 - [Sharpe Rug Check](https://www.sharpe.ai/rug-check) - Free token safety scanner and rug pull checker with a 0-100 risk score across Solana, Ethereum, Base, BSC, Arbitrum, and Polygon. Honeypot simulation, mint-authority detection, liquidity-lock verification, and holder-concentration analysis. No signup, public REST API.
 - [TRONSEC](https://tronsec.io/app/) - Client-side TRON security toolkit: wallet analysis, AML heuristics, contract scanning, transaction decoding, and phishing URL checks. No wallet connection required. [Source](https://github.com/jamejohns/tronsec).
 - [OnChainRisk](https://onchainrisk.io/) - Wallet, token, and smart-contract risk scoring API for Web3 teams; surfaces risk signals such as malicious-token patterns, fund-flow exposure, counterparties, and labels.
+- [PublicAML](https://publicaml.org/) - Free, non-profit AML/KYT wallet screening: paste any BTC, ETH, BNB Chain, or TRON address for a risk score, sanctions status, source of funds, and counterparties. No signup; keyless public API and Telegram bot.
 
 ### x402 Payments Protocol
 


### PR DESCRIPTION
Adds **PublicAML** (https://publicaml.org/) under *Risk Management*, alongside the existing wallet/address risk tools (OnChainRisk, TRONSEC, Sharpe Rug Check).

PublicAML is a free, non-profit AML/KYT tool: paste any Bitcoin, Ethereum, BNB Chain or TRON address and get a risk score, sanctions status, entity/category attribution, source of funds and counterparties — no signup, no card, no API key. It also offers a keyless public KYT API and a Telegram bot. Entry follows the section's format.