### PR TITLE
Add FarmDash to AI & LLM & MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,7 @@
 - [AgentsCoin](https://github.com/axiosdevs/agentscoin-mcp) - Give your AI agent its own money on a live EVM chain (chainId 24368): wallet, faucet, send, and create/trade tokens via MCP.
 - [BaseLens](https://github.com/YoungAlgy/baselens) - Pay-per-call AI agent that reads any Base address and returns a structured risk/activity report over x402 (a few cents in USDC). Built with Coinbase's CDP SDK and Anthropic's API.
 - [AgentServices](https://github.com/vbkotecha/aiservices-api) 📇 ☁️ - Crypto/financial market data APIs for AI agents. 54 services, 97 endpoints, 37 MCP tools, 41 x402-paid endpoints (USDC on Base). Prices, OHLCV, DeFi yields, DEX quotes, on-chain analytics, social sentiment, gas tracker. Remote MCP server (TypeScript, cloud-hosted).
+- [FarmDash](https://www.farmdash.one/agents) - Zero-custody DeFi agent infrastructure: 84 MCP tools, OpenAPI (45 ops), TS + Python agent SDKs, x402 flow, EVM swaps and read-only Solana previews (docs link; source repo private during pre-release).
 
 ## Gas Tracker & Optimization
 


### PR DESCRIPTION
Adds FarmDash Agent OS to AI & LLM & MCP: zero-custody DeFi agent infrastructure (84 MCP tools, OpenAPI with 45 ops, TS + Python agent SDKs, x402 flow, EVM swaps, read-only Solana previews). Entry links live public docs https://www.farmdash.one/agents (openapi.yaml, .well-known/mcp.json); source repo (Parmasanandgarlic/farmdashbeta) is private during pre-release hardening, link will move to the public repo once visibility flips.