### PR TITLE
Add AYZO to Risk Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@
 - [Sharpe Rug Check](https://www.sharpe.ai/rug-check) - Free token safety scanner and rug pull checker with a 0-100 risk score across Solana, Ethereum, Base, BSC, Arbitrum, and Polygon. Honeypot simulation, mint-authority detection, liquidity-lock verification, and holder-concentration analysis. No signup, public REST API.
 - [TRONSEC](https://tronsec.io/app/) - Client-side TRON security toolkit: wallet analysis, AML heuristics, contract scanning, transaction decoding, and phishing URL checks. No wallet connection required. [Source](https://github.com/jamejohns/tronsec).
 - [OnChainRisk](https://onchainrisk.io/) - Wallet, token, and smart-contract risk scoring API for Web3 teams; surfaces risk signals such as malicious-token patterns, fund-flow exposure, counterparties, and labels.
+-  [AYZO](https://ayzo.io/) - Evidence-first on-chain intelligence for token, wallet, relationship, and funding research across 15+ blockchains.
 
 ### x402 Payments Protocol
 


### PR DESCRIPTION
Adds AYZO to the Risk Management section.

AYZO is an evidence-first on-chain intelligence platform for token, wallet, relationship, and funding research across 15+ blockchains.

Website: https://ayzo.io/
Product: https://app.ayzo.io/