### PR TITLE
Add Pending - Read-only EVM transaction diagnosis tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@
 - [Sharpe Rug Check](https://www.sharpe.ai/rug-check) - Free token safety scanner and rug pull checker with a 0-100 risk score across Solana, Ethereum, Base, BSC, Arbitrum, and Polygon. Honeypot simulation, mint-authority detection, liquidity-lock verification, and holder-concentration analysis. No signup, public REST API.
 - [TRONSEC](https://tronsec.io/app/) - Client-side TRON security toolkit: wallet analysis, AML heuristics, contract scanning, transaction decoding, and phishing URL checks. No wallet connection required. [Source](https://github.com/jamejohns/tronsec).
 - [OnChainRisk](https://onchainrisk.io/) - Wallet, token, and smart-contract risk scoring API for Web3 teams; surfaces risk signals such as malicious-token patterns, fund-flow exposure, counterparties, and labels.
+- [Pending](https://pending.one) - Zero-wallet EVM transaction status and stuck transaction diagnosis engine for Ethereum, Polygon, and Base. Identifies nonce gaps, gas fee surges, and replacement fees with 100% read-only security. [Source](https://github.com/adharshitt/pending).
 
 ### x402 Payments Protocol
 


### PR DESCRIPTION
### Summary
Adds [Pending](https://pending.one) to the Risk Management & Security tools section.

### About Pending
- **URL:** https://pending.one
- **Source:** https://github.com/adharshitt/pending
- **Description:** A 100% read-only diagnostic engine for Ethereum, Polygon, and Base. It inspects public mempool conditions, detects sequential account nonce gaps, models EIP-1559 base fee surges, and computes exact replacement fees.
- **Security Invariant:** Zero wallet connection requirement, 100% free and open access.