### PR TITLE
Add DeFade

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@
 - [Sharpe Rug Check](https://www.sharpe.ai/rug-check) - Free token safety scanner and rug pull checker with a 0-100 risk score across Solana, Ethereum, Base, BSC, Arbitrum, and Polygon. Honeypot simulation, mint-authority detection, liquidity-lock verification, and holder-concentration analysis. No signup, public REST API.
 - [TRONSEC](https://tronsec.io/app/) - Client-side TRON security toolkit: wallet analysis, AML heuristics, contract scanning, transaction decoding, and phishing URL checks. No wallet connection required. [Source](https://github.com/jamejohns/tronsec).
 - [OnChainRisk](https://onchainrisk.io/) - Wallet, token, and smart-contract risk scoring API for Web3 teams; surfaces risk signals such as malicious-token patterns, fund-flow exposure, counterparties, and labels.
+- [DeFade](https://defade.org) - Token risk scanner for Ethereum, Base and Solana. 0-100 rug score covering launch-bundle detection that follows sell-and-forward hops, fresh-wallet cohorts traced to the exchange that funded them, sniper hold/sold/transferred classification, and deployer track record across past launches. Free tier, REST API, and an MCP server.
 
 ### x402 Payments Protocol
 


### PR DESCRIPTION
Adds [DeFade](https://defade.org) to **Risk Management**, alongside the other token-safety scanners there (Sharpe Rug Check, OnChainRisk, Web3 Antivirus).

It covers Ethereum, Base and Robinhood Chain on the EVM side, plus Solana. Where it goes further than authority/LP/honeypot checks is actor attribution:

- Launch bundles followed through sell-and-forward hops, so a bundler who moved coins to a second wallet before dumping is counted as exited rather than as a holder
- Fresh-wallet cohorts traced back to the exchange that funded them, with wallets sharing a funder linked together
- Snipers classified as still holding / sold / transferred out
- Deployer reputation across the creator's previous launches

Free tier with no wallet connection, plus a REST API and an MCP server (`npx defade-mcp`, or hosted at https://api.defade.org/mcp).

One link, appended in the position the section's recent entries use. No token, no paid placement.